### PR TITLE
Refactor document editing to inline table editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Complete the `config.json` file with the following content, replacing placeholde
 
 #### start the API
 ```bash
-sudo docker build -t electrostore/api:latest electrostoreAPI
+sudo docker build -t ghcr.io/vampi62/electrostore/api:local electrostoreAPI
 sudo docker run -d --name electrostoreAPI \
  --restart always \
  --network electrostore \
@@ -134,7 +134,7 @@ sudo docker run -d --name electrostoreAPI \
  --cap-drop ALL \
  ghcr.io/vampi62/electrostore/api:local
 
-sudo docker build -t electrostore/ia:local electrostoreIA
+sudo docker build -t ghcr.io/vampi62/electrostore/ia:local electrostoreIA
 sudo docker run -d --name electrostoreIA \
  --restart always \
  --network electrostore \
@@ -152,11 +152,12 @@ sudo docker run -d --name electrostoreIA \
 #### start the web interface
 set VUE_API_URL with the complete url of the API (ex: https://api.electrostore.com:443/api)
 ```bash
-sudo docker build -t electrostore/front:local electrostoreFRONT
+sudo docker build -t ghcr.io/vampi62/electrostore/front:local electrostoreFRONT
 sudo docker run -d --name electrostoreFRONT \
  --restart always \
+ --network electrostore \
  -p 8080:80 \
- -e VUE_API_URL=<VUE_API_URL> \
+ -e VUE_API_URL=http://192.168.2.55:5002 \
  --security-opt no-new-privileges=true \
  --cap-drop ALL \
  ghcr.io/vampi62/electrostore/front:local

--- a/electrostoreFRONT/entrypoint.sh
+++ b/electrostoreFRONT/entrypoint.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
-
 # search and replace the placeholder with the actual API URL
 for file in /usr/local/apache2/htdocs/assets/*.js; do
     sed -i "s|http://localhost/placeholder/api|"${VUE_API_URL}"|g" $file
 done
-
 exec "$@"

--- a/electrostoreFRONT/src/locales/en/command.json
+++ b/electrostoreFRONT/src/locales/en/command.json
@@ -77,8 +77,6 @@
 	"VCommandDocumentAddTitle": "Add a document",
 	"VCommandDocumentAdd": "Add",
 	"VCommandDocumentCancel": "Cancel",
-	"VCommandDocumentEditTitle": "Edit document",
-	"VCommandDocumentEdit": "Edit",
 	"VCommandDeleteTitle": "Delete command",
 	"VCommandDeleteText": "Are you sure you want to delete this command ?",
 	"VCommandCommentaires": "Comments",

--- a/electrostoreFRONT/src/locales/en/item.json
+++ b/electrostoreFRONT/src/locales/en/item.json
@@ -120,8 +120,6 @@
 	"VItemDocumentNamePlaceholder": "Document name",
 	"VItemDocumentCancel": "Cancel",
 	"VItemDocumentAdd": "Add",
-	"VItemDocumentEditTitle": "Edit document",
-	"VItemDocumentEdit": "Edit",
 	"VItemDocumentDeleteTitle": "Delete document",
 	"VItemDocumentDeleteText": "Are you sure you want to delete this document?",
 	"VItemImageAddTitle": "Add image",

--- a/electrostoreFRONT/src/locales/en/projet.json
+++ b/electrostoreFRONT/src/locales/en/projet.json
@@ -85,8 +85,6 @@
 	"VProjetDocumentNamePlaceholder": "Document name",
 	"VProjetDocumentCancel": "Cancel",
 	"VProjetDocumentAdd": "Add",
-	"VProjetDocumentEditTitle": "Edit document",
-	"VProjetDocumentEdit": "Edit",
 	"VProjetDocumentDeleteTitle": "Delete document",
 	"VProjetDocumentDeleteText": "Are you sure you want to delete this document?",
 	"VProjetItemTitle": "Item",

--- a/electrostoreFRONT/src/locales/fr/command.json
+++ b/electrostoreFRONT/src/locales/fr/command.json
@@ -77,8 +77,6 @@
 	"VCommandDocumentAddTitle": "Ajouter un document",
 	"VCommandDocumentAdd": "Ajouter",
 	"VCommandDocumentCancel": "Annuler",
-	"VCommandDocumentEditTitle": "Modifier le document",
-	"VCommandDocumentEdit": "Modifier",
 	"VCommandDeleteTitle": "Supprimer la commande",
 	"VCommandDeleteText": "Êtes-vous sûr de vouloir supprimer cette commande ?",
 	"VCommandCommentaires": "Commentaires",

--- a/electrostoreFRONT/src/locales/fr/item.json
+++ b/electrostoreFRONT/src/locales/fr/item.json
@@ -120,8 +120,6 @@
 	"VItemDocumentNamePlaceholder": "Nom du document",
 	"VItemDocumentCancel": "Annuler",
 	"VItemDocumentAdd": "Ajouter",
-	"VItemDocumentEditTitle": "Modifier le document",
-	"VItemDocumentEdit": "Modifier",
 	"VItemDocumentDeleteTitle": "Supprimer le document",
 	"VItemDocumentDeleteText": "Êtes-vous sûr de vouloir supprimer ce document ?",
 	"VItemImageAddTitle": "Ajouter une image",

--- a/electrostoreFRONT/src/locales/fr/projet.json
+++ b/electrostoreFRONT/src/locales/fr/projet.json
@@ -85,8 +85,6 @@
 	"VProjetDocumentNamePlaceholder": "Nom du document",
 	"VProjetDocumentCancel": "Annuler",
 	"VProjetDocumentAdd": "Ajouter",
-	"VProjetDocumentEditTitle": "Modifier le document",
-	"VProjetDocumentEdit": "Modifier",
 	"VProjetDocumentDeleteTitle": "Supprimer le document",
 	"VProjetDocumentDeleteText": "Êtes-vous sûr de vouloir supprimer ce document?",
 	"VProjetItemTitle": "Article",

--- a/electrostoreFRONT/src/views/CommandView.vue
+++ b/electrostoreFRONT/src/views/CommandView.vue
@@ -124,16 +124,11 @@ const commandDelete = async() => {
 
 // document
 const documentAddModalShow = ref(false);
-const documentEditModalShow = ref(false);
 const documentDeleteModalShow = ref(false);
 const documentModalData = ref({ id_command_document: null, name_command_document: "", document: null, isEdit: false });
 const documentAddOpenModal = () => {
 	documentModalData.value = { name_command_document: "", document: null, isEdit: false };
 	documentAddModalShow.value = true;
-};
-const documentEditOpenModal = (doc) => {
-	documentModalData.value = { id_command_document: doc.id_command_document, name_command_document: doc.name_command_document, document: null, isEdit: true };
-	documentEditModalShow.value = true;
 };
 const documentDeleteOpenModal = (doc) => {
 	documentModalData.value = doc;
@@ -152,10 +147,10 @@ const documentAdd = async() => {
 	}
 	documentAddModalShow.value = false;
 };
-const documentEdit = async() => {
+const documentEdit = async(row) => {
 	try {
-		schemaEditDocument.validateSync(documentModalData.value, { abortEarly: false });
-		await commandsStore.updateDocument(commandId, documentModalData.value.id_command_document, documentModalData.value);
+		schemaEditDocument.validateSync(row, { abortEarly: false });
+		await commandsStore.updateDocument(commandId, row.id_command_document, row);
 		addNotification({ message: "command.VCommandDocumentUpdated", type: "success", i18n: true });
 	} catch (e) {
 		e.inner.forEach((error) => {
@@ -163,7 +158,6 @@ const documentEdit = async() => {
 		});
 		return;
 	}
-	documentEditModalShow.value = false;
 };
 const documentDelete = async() => {
 	try {
@@ -334,15 +328,25 @@ const schemaItem = Yup.object().shape({
 });
 
 const labelTableauDocument = ref([
-	{ label: "command.VCommandDocumentName", sortable: true, key: "name_command_document", type: "text" },
+	{ label: "command.VCommandDocumentName", sortable: true, key: "name_command_document", type: "text", canEdit: true },
 	{ label: "command.VCommandDocumentType", sortable: true, key: "type_command_document", type: "text" },
 	{ label: "command.VCommandDocumentDate", sortable: true, key: "date_command_document", type: "datetime" },
 	{ label: "command.VCommandDocumentActions", sortable: false, key: "", type: "buttons", buttons: [
 		{
 			label: "",
 			icon: "fa-solid fa-edit",
-			action: (row) => documentEditOpenModal(row),
+			condition: "!rowData.tmp",
+			action: (row) => {
+				row.tmp = { ...row };
+			},
 			class: "text-blue-500 cursor-pointer hover:text-blue-600",
+		},
+		{
+			label: "",
+			icon: "fa-solid fa-save",
+			condition: "rowData.tmp",
+			action: (row) => documentEdit(row),
+			class: "text-green-500 cursor-pointer hover:text-green-600",
 		},
 		{
 			label: "",
@@ -546,7 +550,7 @@ const labelTableauModalItem = ref([
 					:total-count="Number(commandsStore.documentsTotalCount[commandId] || 0)"
 					:loaded-count="Object.keys(commandsStore.documents[commandId] || {}).length"
 					:fetch-function="(offset, limit) => commandsStore.getDocumentByInterval(commandId, limit, offset)"
-					:tableau-css="{ component: 'max-h-64', tr: 'transition duration-150 ease-in-out hover:bg-gray-200 even:bg-gray-10' }"
+					:tableau-css="{ component: 'max-h-64' }"
 				/>
 			</div>
 		</div>
@@ -623,33 +627,6 @@ const labelTableauModalItem = ref([
 					</button>
 					<button type="button" @click="documentAdd" class="px-4 py-2 bg-blue-500 text-white rounded">
 						{{ $t('command.VCommandDocumentAdd') }}
-					</button>
-				</div>
-			</Form>
-		</div>
-	</div>
-	<div v-if="documentEditModalShow" class="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center"
-		@click="documentEditModalShow = false">
-		<div class="bg-white p-6 rounded shadow-lg w-96" @click.stop>
-			<Form :validation-schema="schemaEditDocument" v-slot="{ errors }">
-				<h2 class="text-xl mb-4">{{ $t('command.VCommandDocumentEditTitle') }}</h2>
-				<div class="flex flex-col">
-					<div class="flex flex-col">
-						<Field name="name_command_document" type="text"
-							v-model="documentModalData.name_command_document"
-							:placeholder="$t('command.VCommandDocumentNamePlaceholder')"
-							class="w-full p-2 border rounded"
-							:class="{ 'border-red-500': errors.name_command_document }" />
-						<span class="text-red-500 h-5 w-80 text-sm">{{ errors.name_command_document || ' ' }}</span>
-					</div>
-				</div>
-				<div class="flex justify-end space-x-2">
-					<button type="button" @click="documentEditModalShow = false"
-						class="px-4 py-2 bg-gray-300 rounded">
-						{{ $t('command.VCommandDocumentCancel') }}
-					</button>
-					<button type="button" @click="documentEdit" class="px-4 py-2 bg-blue-500 text-white rounded">
-						{{ $t('command.VCommandDocumentEdit') }}
 					</button>
 				</div>
 			</Form>

--- a/electrostoreFRONT/src/views/CommandView.vue
+++ b/electrostoreFRONT/src/views/CommandView.vue
@@ -343,9 +343,18 @@ const labelTableauDocument = ref([
 		},
 		{
 			label: "",
+			icon: "fa-solid fa-times",
+			condition: "rowData.tmp",
+			action: (row) => {
+				row.tmp = null;
+			},
+			class: "text-gray-500 cursor-pointer hover:text-gray-600",
+		},
+		{
+			label: "",
 			icon: "fa-solid fa-save",
 			condition: "rowData.tmp",
-			action: (row) => documentEdit(row),
+			action: (row) => documentEdit(row.tmp),
 			class: "text-green-500 cursor-pointer hover:text-green-600",
 		},
 		{

--- a/electrostoreFRONT/src/views/ItemView.vue
+++ b/electrostoreFRONT/src/views/ItemView.vue
@@ -219,16 +219,11 @@ const boxSave = async(box) => {
 
 // document
 const documentAddModalShow = ref(false);
-const documentEditModalShow = ref(false);
 const documentDeleteModalShow = ref(false);
 const documentModalData = ref({ id_item_document: null, name_item_document: "", document: null, isEdit: false });
 const documentAddOpenModal = () => {
 	documentModalData.value = { name_item_document: "", document: null, isEdit: false };
 	documentAddModalShow.value = true;
-};
-const documentEditOpenModal = (doc) => {
-	documentModalData.value = { id_item_document: doc.id_item_document, name_item_document: doc.name_item_document, document: null, isEdit: true };
-	documentEditModalShow.value = true;
 };
 const documentDeleteOpenModal = (doc) => {
 	documentModalData.value = doc;
@@ -247,10 +242,10 @@ const documentAdd = async() => {
 	}
 	documentAddModalShow.value = false;
 };
-const documentEdit = async() => {
+const documentEdit = async(row) => {
 	try {
-		schemaEditDocument.validateSync(documentModalData.value, { abortEarly: false });
-		await itemsStore.updateDocument(itemId, documentModalData.value.id_item_document, documentModalData.value);
+		schemaEditDocument.validateSync(row, { abortEarly: false });
+		await itemsStore.updateDocument(itemId, row.id_item_document, row);
 		addNotification({ message: "item.VItemDocumentUpdated", type: "success", i18n: true });
 	} catch (e) {
 		e.inner.forEach((error) => {
@@ -258,7 +253,6 @@ const documentEdit = async() => {
 		});
 		return;
 	}
-	documentEditModalShow.value = false;
 };
 const documentDelete = async() => {
 	try {
@@ -438,15 +432,25 @@ const schemaAddImage = Yup.object().shape({
 });
 
 const labelTableauDocument = ref([
-	{ label: "item.VItemDocumentName", sortable: true, key: "name_item_document", type: "text" },
+	{ label: "item.VItemDocumentName", sortable: true, key: "name_item_document", type: "text", canEdit: true },
 	{ label: "item.VItemDocumentType", sortable: true, key: "type_item_document", type: "text" },
 	{ label: "item.VItemDocumentDate", sortable: true, key: "date_item_document", type: "datetime" },
 	{ label: "item.VItemDocumentActions", sortable: false, key: "", type: "buttons", buttons: [
 		{
 			label: "",
 			icon: "fa-solid fa-edit",
-			action: (row) => documentEditOpenModal(row),
+			condition: "!rowData.tmp",
+			action: (row) => {
+				row.tmp = { ...row };
+			},
 			class: "text-blue-500 cursor-pointer hover:text-blue-600",
+		},
+		{
+			label: "",
+			icon: "fa-solid fa-save",
+			condition: "rowData.tmp",
+			action: (row) => documentEdit(row),
+			class: "text-green-500 cursor-pointer hover:text-green-600",
 		},
 		{
 			label: "",
@@ -655,7 +659,7 @@ const labelTableauProjet = ref([
 					:total-count="Number(itemsStore.documentsTotalCount[itemId])"
 					:loaded-count="Object.keys(itemsStore.documents[itemId] || {}).length"
 					:fetch-function="(offset, limit) => itemsStore.getDocumentByInterval(itemId, limit, offset)"
-					:tableau-css="{ component: 'max-h-64', tr: 'transition duration-150 ease-in-out hover:bg-gray-200 even:bg-gray-10' }"
+					:tableau-css="{ component: 'max-h-64' }"
 				/>
 			</div>
 		</div>
@@ -816,33 +820,6 @@ const labelTableauProjet = ref([
 					</button>
 					<button type="button" @click="documentAdd" class="px-4 py-2 bg-blue-500 text-white rounded">
 						{{ $t('item.VItemDocumentAdd') }}
-					</button>
-				</div>
-			</Form>
-		</div>
-	</div>
-	<div v-if="documentEditModalShow" class="fixed inset-0 bg-black bg-opacity-50 flex justify-center items-center"
-		@click="documentEditModalShow = false">
-		<div class="bg-white p-6 rounded shadow-lg w-96" @click.stop>
-			<Form :validation-schema="schemaEditDocument" v-slot="{ errors }">
-				<h2 class="text-xl mb-4">{{ $t('item.VItemDocumentEditTitle') }}</h2>
-				<div class="flex flex-col">
-					<div class="flex flex-col">
-						<Field name="name_item_document" type="text"
-							v-model="documentModalData.name_item_document"
-							:placeholder="$t('item.VItemDocumentNamePlaceholder')"
-							class="w-full p-2 border rounded"
-							:class="{ 'border-red-500': errors.name_item_document }" />
-						<span class="text-red-500 h-5 w-80 text-sm">{{ errors.name_item_document || ' ' }}</span>
-					</div>
-				</div>
-				<div class="flex justify-end space-x-2">
-					<button type="button" @click="documentEditModalShow = false"
-						class="px-4 py-2 bg-gray-300 rounded">
-						{{ $t('item.VItemDocumentCancel') }}
-					</button>
-					<button type="button" @click="documentEdit" class="px-4 py-2 bg-blue-500 text-white rounded">
-						{{ $t('item.VItemDocumentEdit') }}
 					</button>
 				</div>
 			</Form>

--- a/electrostoreFRONT/src/views/ItemView.vue
+++ b/electrostoreFRONT/src/views/ItemView.vue
@@ -447,9 +447,18 @@ const labelTableauDocument = ref([
 		},
 		{
 			label: "",
+			icon: "fa-solid fa-times",
+			condition: "rowData.tmp",
+			action: (row) => {
+				row.tmp = null;
+			},
+			class: "text-gray-500 cursor-pointer hover:text-gray-600",
+		},
+		{
+			label: "",
 			icon: "fa-solid fa-save",
 			condition: "rowData.tmp",
-			action: (row) => documentEdit(row),
+			action: (row) => documentEdit(row.tmp),
 			class: "text-green-500 cursor-pointer hover:text-green-600",
 		},
 		{
@@ -653,7 +662,7 @@ const labelTableauProjet = ref([
 					class="bg-blue-500 text-white px-4 py-2 rounded mb-4 hover:bg-blue-600">
 					{{ $t('item.VItemAddDocument') }}
 				</button>
-				<Tableau :labels="labelTableauDocument" :meta="{ key: 'id_command_document' }"
+				<Tableau :labels="labelTableauDocument" :meta="{ key: 'id_item_document' }"
 					:store-data="[itemsStore.documents[itemId]]"
 					:loading="itemsStore.documentsLoading"
 					:total-count="Number(itemsStore.documentsTotalCount[itemId])"

--- a/electrostoreFRONT/src/views/ProjetView.vue
+++ b/electrostoreFRONT/src/views/ProjetView.vue
@@ -342,9 +342,18 @@ const labelTableauDocument = ref([
 		},
 		{
 			label: "",
+			icon: "fa-solid fa-times",
+			condition: "rowData.tmp",
+			action: (row) => {
+				row.tmp = null;
+			},
+			class: "text-gray-500 cursor-pointer hover:text-gray-600",
+		},
+		{
+			label: "",
 			icon: "fa-solid fa-save",
 			condition: "rowData.tmp",
-			action: (row) => documentEdit(row),
+			action: (row) => documentEdit(row.tmp),
 			class: "text-green-500 cursor-pointer hover:text-green-600",
 		},
 		{

--- a/tests/electrostoreFRONT/cypress/e2e/login.cy.js
+++ b/tests/electrostoreFRONT/cypress/e2e/login.cy.js
@@ -99,6 +99,14 @@ describe("Login Page", () => {
 				},
 			},
 		}).as("loginRequest");
+		cy.intercept("GET", "**/api/item", {
+			statusCode: 200,
+			body: [],
+			headers: {
+				"Content-Type": "application/json",
+				"X-Total-Count": "0",
+			},
+		}).as("getItems");
 
 		// Fill in the form with valid credentials
 		cy.get("input[type=\"email\"]").type("admin@example.com");


### PR DESCRIPTION
Removed modal-based document editing for commands, items, and projects. Now, document names can be edited directly in the table with inline edit and save actions. Updated i18n files to remove unused edit document strings in both English and French locales.