### PR TITLE
Add datalist filter type to Filter component

### DIFF
--- a/electrostoreFRONT/src/components/Filter.vue
+++ b/electrostoreFRONT/src/components/Filter.vue
@@ -1,13 +1,13 @@
 <template>
 	<div>
-		<label v-if="label.length > 0" :for="`filter-input-${this.$.uid}`" class="text-sm text-gray-700 ml-2">{{ $t(label) }}</label>
+		<label v-if="label.length > 0" :for="`filter-input-${this.$.uid}`" class="text-sm text-gray-700 mr-2">{{ $t(label) }}</label>
+		<div>
 		<template v-if="type === 'select'">
 			<select
 				:id="`filter-input-${this.$.uid}`"
 				class="border border-gray-300 rounded px-2 py-1"
-				:class="[classCss, label.length > 0 ? 'ml-2' : '']"
-				@change="$emit('updateText', $event.target.value)"
-			>
+				:class="[classCss, label.length > 0 ? 'mr-2' : '']"
+				@change="$emit('updateText', $event.target.value)">
 				<option value=""></option>
 				<template v-if="options">
 					<option v-for="option in options" :key="option[0]" :value="option[0]">{{ option[1] }}
@@ -15,20 +15,60 @@
 				</template>
 			</select>
 		</template>
+		<template v-else-if="type === 'datalist'">
+			<div class="relative max-w-xs mx-auto">
+				<input
+					ref="filterInput"
+					:id="`filter-input-${this.$.uid}`"
+					type="text"
+					class="border border-gray-300 rounded px-2 py-1"
+					:class="[classCss, label.length > 0 ? 'mr-2' : '']"
+					:placeholder="placeholder"
+					v-model="inputText"
+					@focus="isOpen = true; inputText='', startEventUpdatePosition()"
+					@blur="isOpen = false; validateInput(); endEventUpdatePosition()" />
+				<div class="absolute inset-y-0 right-0 flex items-center pr-3 pointer-events-none">
+					<svg
+						class="w-4 h-4 text-gray-500"
+						fill="none"
+						stroke="currentColor"
+						viewBox="0 0 24 24"
+						xmlns="http://www.w3.org/2000/svg">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M19 9l-7 7-7-7" />
+					</svg>
+				</div>
+			</div>
+			<teleport to="body">
+				<div v-show="isOpen"
+					:id="`filter-list-${this.$.uid}`"
+					class="absolute z-50 border max-h-48 overflow-y-auto bg-white left-0" style="width: calc(100% - 8px);">
+					<div v-for="option in filterOption" :key="option[0]"
+						@mousedown.prevent="selectOption(option)"
+						class="flex flex-col p-2 hover:bg-gray-100 cursor-pointer">
+						<span class="text-sm">{{ option[1] }}</span>
+					</div>
+				</div>
+			</teleport>
+		</template>
 		<template v-else>
 			<input
 				:id="`filter-input-${this.$.uid}`"
 				:type="type"
 				class="border border-gray-300 rounded px-2 py-1"
-				:class="[classCss, label.length > 0 ? 'ml-2' : '']"
+				:class="[classCss, label.length > 0 ? 'mr-2' : '']"
 				:placeholder="placeholder"
-				@input="$emit('updateText', $event.target.value)"
-			/>
+				@input="$emit('updateText', $event.target.value)" />
 		</template>
+		</div>
 	</div>
 </template>
 
 <script>
+import { nextTick } from "vue";
 export default {
 	name: "Filter",
 	props: {
@@ -69,6 +109,67 @@ export default {
 			default: () => [],
 		},
 	},
+	data() {
+		return {
+			isOpen: false,
+			inputText: "",
+		};
+	},
 	emits: ["updateText"],
+	computed: {
+		filterOption() {
+			return Object.values(this.options).filter((element) => {
+				if (this.inputText !== "") {
+					return element[1].toLowerCase().includes(this.inputText.toLowerCase());
+				}
+				return true;
+			});
+		},
+	},
+	methods: {
+		selectOption(option){
+			this.inputText = option[1];
+			this.isOpen = false;
+			this.$emit("updateText", option[0]);
+			this.$refs.filterInput.blur();
+		},
+		validateInput(){
+			let result = Object.values(this.options).find((option) => {
+				return option[1].toLowerCase() === this.inputText.toLowerCase();
+			});
+			if (result) {
+				this.inputText = result[1];
+				this.$emit("updateText", result[0]);
+			} else {
+				this.inputText = "";
+				this.$emit("updateText", "");
+			}
+		},
+		startEventUpdatePosition(){
+			window.addEventListener("scroll", this.updatePosition, true);
+			window.addEventListener("resize", this.updatePosition);
+			nextTick(() => {
+				this.updatePosition();
+			});
+		},
+		endEventUpdatePosition(){
+			window.removeEventListener("scroll", this.updatePosition, true);
+			window.removeEventListener("resize", this.updatePosition);
+		},
+		updatePosition(){
+			if (!this.isOpen) {
+				return;
+			}
+			let inputElement = this.$refs.filterInput;
+			let listElement = document.getElementById(`filter-list-${this.$.uid}`);
+			if (inputElement && listElement) {
+				let rect = inputElement.getBoundingClientRect();
+				listElement.style.top = `${rect.bottom + window.scrollY}px`;
+				listElement.style.left = `${rect.left + window.scrollX}px`;
+				listElement.style.width = `${rect.width}px`;
+			}
+		},
+
+	},
 };
 </script>

--- a/electrostoreFRONT/src/components/FilterContainer.vue
+++ b/electrostoreFRONT/src/components/FilterContainer.vue
@@ -7,7 +7,7 @@
 			:placeholder="filter?.placeholder"
 			:class-css="filter?.class"
 			:class="filter?.class"
-			:options="filter?.options"
+			:options="filter?.options && filter.options.length > 0 ? filterOption(filter) : []"
 			@update-text="(value) => updateText(index, value)"
 		/>
 	</div>
@@ -117,6 +117,24 @@ export default {
 					filter.value = value;
 				}
 			});
+		},
+		filterOption(filter) {
+			if ((filter.type === "select" || filter.type === "datalist") && filter.options.length > 0) {
+				const optionsSet = new Set();
+				filter.options.forEach((option) => {
+					Object.values(this.storeData).forEach((element) => {
+						if (filter.subPath) {
+							if (element[filter.subPath].some((subElement) => subElement[filter.key] === option[0])) {
+								optionsSet.add(option);
+							}
+						} else if (element[filter.key] === option[0]) {
+							optionsSet.add(option);
+						}
+					});
+				});
+				return Array.from(optionsSet);
+			}
+			return filter.options;
 		},
 	},
 	watch: {

--- a/electrostoreFRONT/src/views/CommandsView.vue
+++ b/electrostoreFRONT/src/views/CommandsView.vue
@@ -37,13 +37,13 @@ onMounted(() => {
 });
 
 const filter = ref([
-	{ key: "status_command", value: "", type: "select", options: [["En attente", t("command.VCommandsFilterStatus1")], ["En cours", t("command.VCommandsFilterStatus2")], ["Terminée", t("command.VCommandsFilterStatus3")], ["Annulée", t("command.VCommandsFilterStatus4")]], label: "command.VCommandsFilterStatus", compareMethod: "=" },
+	{ key: "status_command", value: "", type: "datalist", options: [["En attente", t("command.VCommandsFilterStatus1")], ["En cours", t("command.VCommandsFilterStatus2")], ["Terminée", t("command.VCommandsFilterStatus3")], ["Annulée", t("command.VCommandsFilterStatus4")]], label: "command.VCommandsFilterStatus", compareMethod: "=" },
 	{ key: "date_command", value: "", type: "date", label: "command.VCommandsFilterDate", compareMethod: ">=" },
 	{ key: "url_command", value: "", type: "text", label: "command.VCommandsFilterURL", compareMethod: "contain" },
 	{ key: "prix_command", value: "", type: "number", label: "command.VCommandsFilterPriceMin", compareMethod: ">=" },
 	{ key: "prix_command", value: "", type: "number", label: "command.VCommandsFilterPriceMax", compareMethod: "<=" },
 	{ key: "date_livraison_command", value: "", type: "date", label: "command.VCommandsFilterDateL", compareMethod: ">=" },
-	{ key: "id_item", subPath: "commands_items", value: "", type: "select", typeData: "int", options: Object.values(itemsStore.items).map((item) => [item.id_item, item.reference_name_item]), label: "command.VCommandsFilterItem", compareMethod: "=" },
+	{ key: "id_item", subPath: "commands_items", value: "", type: "datalist", typeData: "int", options: Object.values(itemsStore.items).map((item) => [item.id_item, item.reference_name_item]), label: "command.VCommandsFilterItem", compareMethod: "=" },
 ]);
 const tableauLabel = ref([
 	{ label: "command.VCommandsStatus", sortable: true, key: "status_command", type: "text" },

--- a/electrostoreFRONT/src/views/IAsView.vue
+++ b/electrostoreFRONT/src/views/IAsView.vue
@@ -21,7 +21,7 @@ onMounted(() => {
 });
 
 const filter = ref([
-	{ key: "trained_ia", value: undefined, type: "select", dataType: "bool", options: [["false", t("ia.VIasFilterTrained1")], ["true", t("ia.VIasFilterTrained2")]], label: "ia.VIasFilterTrained", compareMethod: "=" },
+	{ key: "trained_ia", value: undefined, type: "datalist", dataType: "bool", options: [["false", t("ia.VIasFilterTrained1")], ["true", t("ia.VIasFilterTrained2")]], label: "ia.VIasFilterTrained", compareMethod: "=" },
 	{ key: "updated_at", value: "", type: "date", label: "ia.VIasFilterDate", compareMethod: ">=" },
 	{ key: "nom_ia", value: "", type: "text", label: "ia.VIasFilterNom", compareMethod: "contain" },
 ]);

--- a/electrostoreFRONT/src/views/InventoryView.vue
+++ b/electrostoreFRONT/src/views/InventoryView.vue
@@ -110,7 +110,7 @@ const filter = ref([
 	{ key: "seuil_min_item", value: "", type: "number", label: "item.VInventoryFilterSeuilMax", compareMethod: "<=" },
 	{ key: "qte_item_box", subPath: "item_boxs", value: "", type: "number", label: "item.VInventoryFilterQuantityMin", compareMethod: ">=" },
 	{ key: "qte_item_box", subPath: "item_boxs", value: "", type: "number", label: "item.VInventoryFilterQuantityMax", compareMethod: "<=" },
-	{ key: "id_tag", subPath: "item_tags", value: "", type: "select", typeData: "int", options: Object.values(tagsStore.tags).map((tag) => [tag.id_tag, tag.nom_tag]), label: "item.VInventoryFilterTag", compareMethod: "=" },
+	{ key: "id_tag", subPath: "item_tags", value: "", type: "datalist", typeData: "int", options: Object.values(tagsStore.tags).map((tag) => [tag.id_tag, tag.nom_tag]), label: "item.VInventoryFilterTag", compareMethod: "=" },
 ]);
 const tableauLabel = ref([
 	{ label: "item.VInventoryName", sortable: true, key: "reference_name_item", type: "text" },

--- a/electrostoreFRONT/src/views/ProjetsView.vue
+++ b/electrostoreFRONT/src/views/ProjetsView.vue
@@ -37,12 +37,12 @@ onMounted(() => {
 });
 
 const filter = ref([
-	{ key: "status_projet", value: "", type: "select", options: [["en attente", t("projet.VProjetsFilterStatus1")], ["en cours", t("projet.VProjetsFilterStatus2")], ["terminée", t("projet.VProjetsFilterStatus3")]], label: "projet.VProjetsFilterStatus", compareMethod: "=" },
+	{ key: "status_projet", value: "", type: "datalist", options: [["en attente", t("projet.VProjetsFilterStatus1")], ["en cours", t("projet.VProjetsFilterStatus2")], ["terminée", t("projet.VProjetsFilterStatus3")]], label: "projet.VProjetsFilterStatus", compareMethod: "=" },
 	{ key: "date_debut_projet", value: "", type: "date", label: "projet.VprojetFilterDate", compareMethod: ">=" },
 	{ key: "nom_projet", value: "", type: "text", label: "projet.VprojetFilterNom", compareMethod: "contain" },
 	{ key: "url_projet", value: "", type: "text", label: "projet.VprojetFilterUrl", compareMethod: "contain" },
 	{ key: "date_fin_projet", value: "", type: "date", label: "projet.VprojetFilterDateEnd", compareMethod: ">=" },
-	{ key: "id_item", subPath: "projets_items", value: "", type: "select", typeData: "int", options: Object.values(itemsStore.items).map((item) => [item.id_item, item.reference_name_item]), label: "projet.VprojetFilterItem", compareMethod: "=" },
+	{ key: "id_item", subPath: "projets_items", value: "", type: "datalist", typeData: "int", options: Object.values(itemsStore.items).map((item) => [item.id_item, item.reference_name_item]), label: "projet.VprojetFilterItem", compareMethod: "=" },
 ]);
 const tableauLabel = ref([
 	{ label: "projet.VProjetsName", sortable: true, key: "nom_projet", type: "text" },

--- a/electrostoreFRONT/src/views/StoresView.vue
+++ b/electrostoreFRONT/src/views/StoresView.vue
@@ -39,7 +39,7 @@ const filter = ref([
 	{ key: "mqtt_name_store", value: "", type: "text", label: "store.VStoresFilterMqttName", compareMethod: "contain" },
 	{ key: "xlength_store", value: "", type: "number", label: "store.VStoresFilterXLength", compareMethod: "<=" },
 	{ key: "ylength_store", value: "", type: "number", label: "store.VStoresFilterYLength", compareMethod: "<=" },
-	{ key: "id_tag", subPath: "stores_tags", value: "", type: "select", typeData: "int", options: Object.values(tagsStore.tags).map((tag) => [tag.id_tag, tag.nom_tag]), label: "store.VStoresFilterTag", compareMethod: "=" },
+	{ key: "id_tag", subPath: "stores_tags", value: "", type: "datalist", typeData: "int", options: Object.values(tagsStore.tags).map((tag) => [tag.id_tag, tag.nom_tag]), label: "store.VStoresFilterTag", compareMethod: "=" },
 ]);
 const tableauLabel = ref([
 	{ label: "store.VStoresName", sortable: true, key: "nom_store", type: "text" },

--- a/electrostoreFRONT/src/views/UsersView.vue
+++ b/electrostoreFRONT/src/views/UsersView.vue
@@ -32,7 +32,7 @@ const filter = ref([
 	{ key: "nom_user", value: "", type: "text", label: "user.VUsersFilterName", compareMethod: "contain" },
 	{ key: "prenom_user", value: "", type: "text", label: "user.VUsersFilterFirstName", compareMethod: "contain" },
 	{ key: "email_user", value: "", type: "text", label: "user.VUsersFilterEmail", compareMethod: "contain" },
-	{ key: "role_user", value: "", type: "select", typeData: "int", options: [[0, t("user.VUsersFilterRole0")], [1, t("user.VUsersFilterRole1")], [2, t("user.VUsersFilterRole2")]], label: "user.VUsersFilterRole", compareMethod: "=" },
+	{ key: "role_user", value: "", type: "datalist", typeData: "int", options: [[0, t("user.VUsersFilterRole0")], [1, t("user.VUsersFilterRole1")], [2, t("user.VUsersFilterRole2")]], label: "user.VUsersFilterRole", compareMethod: "=" },
 ]);
 const tableauLabel = ref([
 	{ label: "user.VUsersName", sortable: true, key: "nom_user", type: "text" },


### PR DESCRIPTION
Introduces a new 'datalist' filter type in the Filter component, allowing users to select or search from a list of options with autocomplete functionality. Updates all relevant views to use 'datalist' instead of 'select' for applicable filters and refines option filtering logic in FilterContainer for better relevance.