### PR TITLE
Use enable/show conditions and fix selects

### DIFF
--- a/electrostoreFRONT/src/components/FormContainer.vue
+++ b/electrostoreFRONT/src/components/FormContainer.vue
@@ -2,7 +2,7 @@
 	<div class="relative mb-6 w-full sm:w-[490px]">
 		<Form :validation-schema="schema" v-slot="{ errors }" @submit.prevent="">
 			<div class="flex flex-col text-gray-700 space-y-2">
-				<div v-for="field in labels" :key="field.key" class="flex flex-col sm:flex-row sm:items-start sm:space-x-2 w-full">
+				<div v-for="field in labelsShow" :key="field.key" class="flex flex-col sm:flex-row sm:items-start sm:space-x-2 w-full">
 					<label class="font-semibold sm:min-w-[140px]" :for="`form-input-${this.$.uid}-${field.key}`">{{ $t(field.label) }}:</label>
 					<div class="flex flex-col flex-1 w-full">
 						<template v-if="field.type === 'checkbox'">
@@ -13,15 +13,21 @@
 									type="checkbox"
 									:checked="field.model"
 									class="form-checkbox h-5 w-5 text-blue-600"
-									:disabled="field?.condition && !evaluateCondition(field.condition)"
+									:disabled="field?.enableCondition && !evaluateCondition(field.enableCondition)"
 								/>
 							</Field>
 						</template>
 						<template v-else-if="field.type === 'select'">
-							<Field :id="`form-input-${this.$.uid}-${field.key}`" :name="field.key" as="select" v-model="storeData[field.key]"
+							<Field v-if="field?.typeData === 'number'" :id="`form-input-${this.$.uid}-${field.key}`" :name="field.key" as="select" v-model.number="storeData[field.key]"
 								class="border border-gray-300 rounded px-2 py-1 w-full focus:outline-none focus:ring focus:ring-blue-300"
 								:class="{ 'border-red-500': errors[field.key] }"
-								:disabled="field?.condition && !evaluateCondition(field.condition)">
+								:disabled="field?.enableCondition && !evaluateCondition(field.enableCondition)">
+								<option v-for="(option, index) in field.options" :key="index" :value="index">{{ option }}</option>
+							</Field>
+							<Field v-else :id="`form-input-${this.$.uid}-${field.key}`" :name="field.key" as="select" v-model="storeData[field.key]"
+								class="border border-gray-300 rounded px-2 py-1 w-full focus:outline-none focus:ring focus:ring-blue-300"
+								:class="{ 'border-red-500': errors[field.key] }"
+								:disabled="field?.enableCondition && !evaluateCondition(field.enableCondition)">
 								<option v-for="(option, index) in field.options" :key="index" :value="index">{{ option }}</option>
 							</Field>
 							<span class="text-red-500 h-5 w-full text-sm">{{ errors[field.key] || ' ' }}</span>
@@ -30,7 +36,7 @@
 							<Field :id="`form-input-${this.$.uid}-${field.key}`" :name="field.key" as="textarea" v-model="storeData[field.key]" :rows="field.rows || 3"
 								class="border border-gray-300 rounded px-2 py-1 w-full focus:outline-none focus:ring focus:ring-blue-300"
 								:class="{ 'border-red-500': errors[field.key] }"
-								:disabled="field?.condition && !evaluateCondition(field.condition)" />
+								:disabled="field?.enableCondition && !evaluateCondition(field.enableCondition)" />
 							<span class="text-red-500 h-5 w-full text-sm">{{ errors[field.key] || ' ' }}</span>
 						</template>
 						<template v-else-if="field.type === 'computed'">
@@ -46,7 +52,7 @@
 								<Field :id="`form-input-${this.$.uid}-${field.key}`" :name="field.key" :type="showPassword ? 'text' : 'password'" v-model="storeData[field.key]"
 									class="border border-gray-300 rounded px-2 py-1 w-full focus:outline-none focus:ring focus:ring-blue-300"
 									:class="{ 'border-red-500': errors[field.key] }"
-									:disabled="field?.condition && !evaluateCondition(field.condition)" />
+									:disabled="field?.enableCondition && !evaluateCondition(field.enableCondition)" />
 								<button type="button" @mouseup="showPassword = false" @mousedown="showPassword = true"
 									class="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-600 hover:text-gray-800">
 									<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -61,7 +67,7 @@
 							<Field :id="`form-input-${this.$.uid}-${field.key}`" :name="field.key" :type="field.type" v-model="storeData[field.key]"
 								class="border border-gray-300 rounded px-2 py-1 w-full focus:outline-none focus:ring focus:ring-blue-300"
 								:class="{ 'border-red-500': errors[field.key] }"
-								:disabled="field?.condition && !evaluateCondition(field.condition)" />
+								:disabled="field?.enableCondition && !evaluateCondition(field.enableCondition)" />
 							<span class="text-red-500 h-5 w-full text-sm">{{ errors[field.key] || ' ' }}</span>
 						</template>
 					</div>
@@ -95,7 +101,8 @@ export default {
 			// - label: string (translation key for the label)
 			// - type: string (input type, e.g., 'text', 'number', 'select', 'checkbox', 'password', 'textarea', 'computed', 'custom')
 			// - model: any (for checkbox type, the boolean model value)
-			// - condition: string (optional, a JavaScript expression to evaluate whether to enable the field)
+			// - enableCondition: string (optional, a JavaScript expression to evaluate whether to enable the field)
+			// - showCondition: string (optional, a JavaScript expression to evaluate whether to show the field)
 			// - options: array (for select inputs, optional, required if type is 'select')
 			// - rows: number (for textarea inputs, optional)
 		},
@@ -121,6 +128,9 @@ export default {
 	computed: {
 		schema() {
 			return this.schemaBuilder(this.labels.find((field) => field.key === "check")?.model || false);
+		},
+		labelsShow() {
+			return this.labels.filter((field) => !field?.showCondition || this.evaluateCondition(field.showCondition));
 		},
 	},
 	components: {

--- a/electrostoreFRONT/src/views/CameraView.vue
+++ b/electrostoreFRONT/src/views/CameraView.vue
@@ -133,11 +133,11 @@ const createSchema = (isChecked) => {
 };
 
 const labelForm = ref([
-	{ key: "nom_camera", label: "camera.Name", type: "text", condition: "func.hasPermission([2])" },
-	{ key: "url_camera", label: "camera.URL", type: "text", condition: "func.hasPermission([2])" },
-	{ key: "check", label: "camera.Check", type: "checkbox", model: isChecked, condition: "func.hasPermission([2])" },
-	{ key: "user_camera", label: "camera.User", type: "text", condition: "func.hasPermission([2]) && form[2].model" },
-	{ key: "mdp_camera", label: "camera.Password", type: "password", condition: "func.hasPermission([2]) && form[2].model" },
+	{ key: "nom_camera", label: "camera.Name", type: "text", enableCondition: "func.hasPermission([2])" },
+	{ key: "url_camera", label: "camera.URL", type: "text", enableCondition: "func.hasPermission([2])" },
+	{ key: "check", label: "camera.Check", type: "checkbox", model: isChecked, enableCondition: "func.hasPermission([2])" },
+	{ key: "user_camera", label: "camera.User", type: "text", enableCondition: "func.hasPermission([2]) && form[2].model" },
+	{ key: "mdp_camera", label: "camera.Password", type: "password", enableCondition: "func.hasPermission([2]) && form[2].model" },
 ]);
 document.querySelector("#view").classList.add("overflow-y-scroll");
 </script>

--- a/electrostoreFRONT/src/views/CommandView.vue
+++ b/electrostoreFRONT/src/views/CommandView.vue
@@ -425,7 +425,7 @@ document.querySelector("#view").classList.add("overflow-y-scroll");
 					:loading="commandsStore.documentsLoading"
 					:total-count="Number(commandsStore.documentsTotalCount[commandId] || 0)"
 					:fetch-function="commandId !== 'new' ? (limit, offset, expand, filter, sort, clear) => commandsStore.getDocumentByInterval(commandId, limit, offset, expand, filter, sort, clear) : undefined"
-					:tableau-css="{ component: 'max-h-64' }"
+					:tableau-css="{ component: 'max-h-64', tr: 'transition duration-150 ease-in-out hover:bg-gray-200 even:bg-gray-10' }"
 				/>
 			</template>
 		</CollapsibleSection>

--- a/electrostoreFRONT/src/views/IAView.vue
+++ b/electrostoreFRONT/src/views/IAView.vue
@@ -117,8 +117,8 @@ const createSchema = () => {
 	});
 };
 const labelForm = [
-	{ key: "nom_ia", label: "ia.Name", type: "text", condition: "func.hasPermission([2])" },
-	{ key: "description_ia", label: "ia.Description", type: "textarea", rows: 4, condition: "func.hasPermission([2])" },
+	{ key: "nom_ia", label: "ia.Name", type: "text", enableCondition: "func.hasPermission([2])" },
+	{ key: "description_ia", label: "ia.Description", type: "textarea", rows: 4, enableCondition: "func.hasPermission([2])" },
 ];
 document.querySelector("#view").classList.add("overflow-y-scroll");
 </script>

--- a/electrostoreFRONT/src/views/StoreView.vue
+++ b/electrostoreFRONT/src/views/StoreView.vue
@@ -316,10 +316,10 @@ const labelTableauModalItem = ref([
 	] },
 ]);
 const labelForm = ref([
-	{ key: "nom_store", label: "store.Name", tledEditionype: "text", condition: "func.hasPermission([2])" },
-	{ key: "mqtt_name_store", label: "store.MQTTName", type: "text", condition: "func.hasPermission([2])" },
-	{ key: "xlength_store", label: "store.XLength", type: "number", condition: "func.hasPermission([2])" },
-	{ key: "ylength_store", label: "store.YLength", type: "number", condition: "func.hasPermission([2])" },
+	{ key: "nom_store", label: "store.Name", tledEditionype: "text", enableCondition: "func.hasPermission([2])" },
+	{ key: "mqtt_name_store", label: "store.MQTTName", type: "text", enableCondition: "func.hasPermission([2])" },
+	{ key: "xlength_store", label: "store.XLength", type: "number", enableCondition: "func.hasPermission([2])" },
+	{ key: "ylength_store", label: "store.YLength", type: "number", enableCondition: "func.hasPermission([2])" },
 ]);
 const labelTableauModalTag = ref([
 	{ label: "store.TagName", sortable: true, key: "nom_tag", valueKey: "nom_tag", type: "text" },

--- a/electrostoreFRONT/src/views/UserView.vue
+++ b/electrostoreFRONT/src/views/UserView.vue
@@ -158,19 +158,19 @@ const createSchema = (isChecked) => {
 };
 
 const labelForm = ref([
-	{ key: "nom_user", label: "user.Name", type: "text", condition: "edition?.id_user === session?.id_user || func.hasPermission([2])" },
-	{ key: "prenom_user", label: "user.FirstName", type: "text", condition: "edition?.id_user === session?.id_user || func.hasPermission([2])" },
-	{ key: "email_user", label: "user.Email", type: "text", condition: "edition?.id_user === session?.id_user || func.hasPermission([2])" },
-	{ key: "role_user", label: "user.Role", type: "select", options: userTypeRole, condition: "func.hasPermission([2])" },
+	{ key: "nom_user", label: "user.Name", type: "text", enableCondition: "edition?.id_user === session?.id_user || func.hasPermission([2])" },
+	{ key: "prenom_user", label: "user.FirstName", type: "text", enableCondition: "edition?.id_user === session?.id_user || func.hasPermission([2])" },
+	{ key: "email_user", label: "user.Email", type: "text", enableCondition: "edition?.id_user === session?.id_user || func.hasPermission([2])" },
+	{ key: "role_user", label: "user.Role", type: "select", options: userTypeRole, enableCondition: "func.hasPermission([2])" },
+	{ key: "check", label: "user.Check", type: "checkbox", model: isChecked, enableCondition: "edition?.id_user === session?.id_user || func.hasPermission([2])",
+		showCondition: "!session?.isSSOUser && (edition?.id_user === session?.id_user || func.hasPermission([2]))" },
+	{ key: "mdp_user", label: "user.Password", type: "password", enableCondition: "(edition?.id_user === session?.id_user || func.hasPermission([2])) && form[4].model",
+		showCondition: "!session?.isSSOUser && (edition?.id_user === session?.id_user || func.hasPermission([2]))" },
+	{ key: "confirm_mdp_user", label: "user.ConfirmPassword", type: "password", enableCondition: "(edition?.id_user === session?.id_user || func.hasPermission([2])) && form[4].model",
+		showCondition: "!session?.isSSOUser && (edition?.id_user === session?.id_user || func.hasPermission([2]))" },
+	{ key: "current_mdp_user", label: "user.CurrentPassword", type: "password", enableCondition: "edition?.id_user === session?.id_user || func.hasPermission([2])",
+		showCondition: "!session?.isSSOUser && (edition?.id_user === session?.id_user || func.hasPermission([2]))" },
 ]);
-if (!authStore.isSSOUser && (authStore.user?.id_user === Number(userId.value) || authStore.hasPermission([2]))) {
-	labelForm.value.push(
-		{ key: "check", label: "user.Check", type: "checkbox", model: isChecked, condition: "edition?.id_user === session?.id_user || func.hasPermission([2])" },
-		{ key: "mdp_user", label: "user.Password", type: "password", condition: "(edition?.id_user === session?.id_user || func.hasPermission([2])) && form[4].model" },
-		{ key: "confirm_mdp_user", label: "user.ConfirmPassword", type: "password", condition: "(edition?.id_user === session?.id_user || func.hasPermission([2])) && form[4].model" },
-		{ key: "current_mdp_user", label: "user.CurrentPassword", type: "password", condition: "edition?.id_user === session?.id_user || func.hasPermission([2])" },
-	);
-}
 
 const filterSession = ref([
 	{ key: "is_revoked", disableLocalFilter: true, value: "", typeData: "bool", valueIfTrue: "true", valueIfFalse: "", preset: false,


### PR DESCRIPTION
Replace the old 'condition' field with 'enableCondition' and add optional 'showCondition' to control field visibility separately. FormContainer now filters labels via a new labelsShow computed property and uses enableCondition for disabling inputs; it also handles select fields with numeric data using v-model.number.