### PR TITLE
chore: Bump dependencies and test requirements

### DIFF
--- a/electrostoreFRONT/package-lock.json
+++ b/electrostoreFRONT/package-lock.json
@@ -1417,9 +1417,9 @@
             "dev": true
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -2396,15 +2396,15 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "dev": true
         },
         "node_modules/lodash-es": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-            "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+            "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
@@ -2474,9 +2474,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
             "funding": [
                 {
                     "type": "github",
@@ -2656,9 +2656,9 @@
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
         },
         "node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "engines": {
                 "node": ">=8.6"
             },
@@ -2704,9 +2704,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.3",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-            "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+            "version": "8.5.10",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+            "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -2721,9 +2721,8 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
-            "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.8",
+                "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -3249,9 +3248,9 @@
             }
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "engines": {
                 "node": ">=12"
             },
@@ -3387,9 +3386,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-            "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+            "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
             "dev": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
@@ -3475,9 +3474,9 @@
             }
         },
         "node_modules/vite/node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "engines": {
                 "node": ">=12"
@@ -3619,14 +3618,17 @@
             "dev": true
         },
         "node_modules/yaml": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-            "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
             "bin": {
                 "yaml": "bin.mjs"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/yocto-queue": {

--- a/electrostoreIA/requirements.txt
+++ b/electrostoreIA/requirements.txt
@@ -2,7 +2,7 @@ Flask==3.1.3
 tensorflow==2.19.0
 numpy==2.0.2
 keras==3.13.2
-pillow==12.1.1
+pillow==12.2.0
 mysql-connector-python==9.2.0
 gunicorn==23.0.0
 minio==7.2.9

--- a/tests/electrostoreFRONT/package-lock.json
+++ b/tests/electrostoreFRONT/package-lock.json
@@ -735,9 +735,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -781,9 +781,9 @@
             }
         },
         "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -1947,9 +1947,9 @@
             "dev": true
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -2791,9 +2791,9 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -4017,9 +4017,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "dev": true
         },
         "node_modules/lodash.merge": {
@@ -4522,9 +4522,9 @@
             "dev": true
         },
         "node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "engines": {
                 "node": ">=12"
@@ -4767,9 +4767,9 @@
             }
         },
         "node_modules/rimraf/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
             "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -5486,9 +5486,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
-            "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+            "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
             "dev": true,
             "dependencies": {
                 "esbuild": "^0.25.0",

--- a/tests/electrostoreIA/requirements.txt
+++ b/tests/electrostoreIA/requirements.txt
@@ -1,4 +1,4 @@
-pytest==7.4.0
+pytest==9.0.3
 pytest-flask==1.3.0
 pandas==2.3.0
 pytest-cov==4.1.0


### PR DESCRIPTION
Update electrostoreIA requirements: pillow 12.1.1 -> 12.2.0 and update tests/electrostoreIA pytest 7.4.0 -> 9.0.3. Regenerate frontend package-lock.json files (electrostoreFRONT and tests/electrostoreFRONT) to pull in upstream npm dependency updates.