### PR TITLE
fix: Add Kafka init, consumer fixes, and notif improvements

### DIFF
--- a/docs/generator/js/generators.js
+++ b/docs/generator/js/generators.js
@@ -242,6 +242,8 @@ services:`;
     volumes:
         - ./config/api/appsettings.json:/app/appsettings.json:ro`;
     }
+    compose += `
+        - ./ia-data:/app/wwwroot`;
 
     if (!config.enableS3) {
         compose += `\n      - ia-models:/app/models`;
@@ -483,7 +485,6 @@ services:`;
       - KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS=0
       - KAFKA_NUM_PARTITIONS=3
       - KAFKA_AUTO_CREATE_TOPICS_ENABLE=true
-      - KAFKA_CREATE_TOPICS="notification-requests:3:1,cronjob-events:3:1,ia-requests:3:1,cron-parcel-tracking:3:1,ia-status:3:1"
     volumes:
       - kafka-data:/var/lib/kafka/data
       - kafka-config:/mnt/shared/config
@@ -1132,7 +1133,16 @@ echo ""
 echo "Configuring Garage S3..."
 
 echo "Starting Garage..."
-docker compose up -d garage
+docker compose up -d garage`;
+
+        if (!isLegacy) {
+            script += `
+
+echo "Initializing Kafka..."
+docker compose up -d kafka`;
+        }
+
+script += `
 
 echo "Waiting for Garage to start (10 seconds)..."
 sleep 10
@@ -1208,6 +1218,27 @@ echo ""
 
 `;
     }
+
+    if (!isLegacy) {
+        script += `# await Kafka readiness
+echo "Waiting for Kafka to be ready..."
+while ! docker exec electrostore-kafka /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 >/dev/null 2>&1; do
+    echo "Kafka is not ready yet. Waiting..."
+    sleep 5
+done
+echo "Kafka is ready."
+
+# Configure Kafka topics
+echo "Configuring Kafka topics..."
+docker exec electrostore-kafka /opt/kafka/bin/kafka-topics.sh --create --topic notification-requests --bootstrap-server localhost:9092 --replication-factor 1 --partitions 3 || echo "Topic 'notification-requests' already exists"
+docker exec electrostore-kafka /opt/kafka/bin/kafka-topics.sh --create --topic cronjob-events --bootstrap-server localhost:9092 --replication-factor 1 --partitions 3 || echo "Topic 'cronjob-events' already exists"
+docker exec electrostore-kafka /opt/kafka/bin/kafka-topics.sh --create --topic ia-requests --bootstrap-server localhost:9092 --replication-factor 1 --partitions 3 || echo "Topic 'ia-requests' already exists"
+docker exec electrostore-kafka /opt/kafka/bin/kafka-topics.sh --create --topic cron-parcel-tracking --bootstrap-server localhost:9092 --replication-factor 1 --partitions 3 || echo "Topic 'cron-parcel-tracking' already exists"
+docker exec electrostore-kafka /opt/kafka/bin/kafka-topics.sh --create --topic ia-status --bootstrap-server localhost:9092 --replication-factor 1 --partitions 3 || echo "Topic 'ia-status' already exists"
+`;
+    }
+
+
 
     script += `# Start all services
 echo "Starting all services..."
@@ -1379,7 +1410,16 @@ Write-Host ""
 Write-Host "Configuring Garage S3..." -ForegroundColor Yellow
 
 Write-Host "Starting Garage..."
-docker compose up -d garage
+docker compose up -d garage`;
+
+        if (!isLegacy) {
+            script += `
+
+Write-Host "Initializing Kafka..."
+docker compose up -d kafka`;
+        }
+
+script += `
 
 Write-Host "Waiting for Garage to start (10 seconds)..."
 Start-Sleep -Seconds 10
@@ -1392,25 +1432,36 @@ docker exec electrostore-garage /garage layout apply --version 1
 
 Write-Host "Creating S3 access keys..."
 $GARAGE_API_ACCESS_KEY = "${config.s3.accessKey}"
-$GARAGE_API_SECRET_KEY = "${config.s3.secretKey}"
-$GARAGE_IA_ACCESS_KEY = "${config.s3Ia.accessKey}"
-$GARAGE_IA_SECRET_KEY = "${config.s3Ia.secretKey}"
+$GARAGE_API_SECRET_KEY = "${config.s3.secretKey}"`;
 
+        if (!isLegacy) {
+            script += `
+$GARAGE_IA_ACCESS_KEY = "${config.s3Ia.accessKey}"
+$GARAGE_IA_SECRET_KEY = "${config.s3Ia.secretKey}"`;
+        }
+script += `
 Write-Host "API Access Key: $GARAGE_API_ACCESS_KEY"
-Write-Host "API Secret Key: $GARAGE_API_SECRET_KEY"
+Write-Host "API Secret Key: $GARAGE_API_SECRET_KEY"`;
+        if (!isLegacy) {
+            script += `
 Write-Host "IA Access Key: $GARAGE_IA_ACCESS_KEY"
-Write-Host "IA Secret Key: $GARAGE_IA_SECRET_KEY"
+Write-Host "IA Secret Key: $GARAGE_IA_SECRET_KEY"`;
+        }
+script += `
 
 Write-Host "Creating bucket ${config.s3.bucket} for API service..."
 docker exec electrostore-garage /garage key import -n electrostore-key --yes $GARAGE_API_ACCESS_KEY $GARAGE_API_SECRET_KEY
 docker exec electrostore-garage /garage bucket create ${config.s3.bucket}
 docker exec electrostore-garage /garage bucket allow --read --write ${config.s3.bucket} --key electrostore-key
-
+`;
+        if (!isLegacy) {
+            script += `
 Write-Host "Creating bucket ${config.s3Ia.bucket} for IA service..."
 docker exec electrostore-garage /garage key import -n electrostore-ia-key --yes $GARAGE_IA_ACCESS_KEY $GARAGE_IA_SECRET_KEY
 docker exec electrostore-garage /garage bucket create ${config.s3Ia.bucket}
 docker exec electrostore-garage /garage bucket allow --read --write ${config.s3Ia.bucket} --key electrostore-ia-key
 `;
+        }
 
         if (config.useVault) {
             script += `
@@ -1440,6 +1491,25 @@ docker compose up -d mqtt
 Write-Host "MQTT configuration completed" -ForegroundColor Green
 Write-Host ""
 
+`;
+    }
+
+    if (!isLegacy) {
+        script += `# await Kafka readiness
+Write-Host "Waiting for Kafka to be ready..."
+do {
+    Start-Sleep -Seconds 5
+    $kafkaReady = docker exec electrostore-kafka /opt/kafka/bin/kafka-broker-api-versions.sh --bootstrap-server localhost:9092 2>$null
+} while ($LASTEXITCODE -ne 0)
+Write-Host "Kafka is ready."
+
+# Configure Kafka topics
+Write-Host "Configuring Kafka topics..."
+docker exec electrostore-kafka /opt/kafka/bin/kafka-topics.sh --create --topic notification-requests --bootstrap-server localhost:9092 --replication-factor 1 --partitions 3 || Write-Host "Topic 'notification-requests' already exists"
+docker exec electrostore-kafka /opt/kafka/bin/kafka-topics.sh --create --topic cronjob-events --bootstrap-server localhost:9092 --replication-factor 1 --partitions 3 || Write-Host "Topic 'cronjob-events' already exists"
+docker exec electrostore-kafka /opt/kafka/bin/kafka-topics.sh --create --topic ia-requests --bootstrap-server localhost:9092 --replication-factor 1 --partitions 3 || Write-Host "Topic 'ia-requests' already exists"
+docker exec electrostore-kafka /opt/kafka/bin/kafka-topics.sh --create --topic cron-parcel-tracking --bootstrap-server localhost:9092 --replication-factor 1 --partitions 3 || Write-Host "Topic 'cron-parcel-tracking' already exists"
+docker exec electrostore-kafka /opt/kafka/bin/kafka-topics.sh --create --topic ia-status --bootstrap-server localhost:9092 --replication-factor 1 --partitions 3 || Write-Host "Topic 'ia-status' already exists"
 `;
     }
 

--- a/electrostoreAPI/Kafka/Producer/IKafkaProducerService.cs
+++ b/electrostoreAPI/Kafka/Producer/IKafkaProducerService.cs
@@ -3,5 +3,6 @@ namespace ElectrostoreAPI.Kafka.Producer;
 public interface IKafkaProducerService
 {
     public Task PublishAsync(string topic, string key, string message, CancellationToken ct = default);
+    public Task<bool> IsConnectedAsync();
     public void Dispose();
 }

--- a/electrostoreAPI/Kafka/Producer/KafkaProducerService.cs
+++ b/electrostoreAPI/Kafka/Producer/KafkaProducerService.cs
@@ -6,12 +6,13 @@ public class KafkaProducerService : IDisposable, IKafkaProducerService
 {
     private readonly IProducer<string, string> _producer;
     private readonly ILogger<KafkaProducerService> _logger;
+    private readonly string _bootstrapServers;
 
     public KafkaProducerService(IConfiguration configuration, ILogger<KafkaProducerService> logger)
     {
         _logger = logger;
-        var bootstrapServers = configuration["Kafka:BootstrapServers"] ?? "kafka:9092";
-        var config = new ProducerConfig { BootstrapServers = bootstrapServers };
+        _bootstrapServers = configuration["Kafka:BootstrapServers"] ?? "kafka:9092";
+        var config = new ProducerConfig { BootstrapServers = _bootstrapServers };
         _producer = new ProducerBuilder<string, string>(config).Build();
     }
 
@@ -26,6 +27,26 @@ public class KafkaProducerService : IDisposable, IKafkaProducerService
         {
             _logger.LogError(ex, "Failed to publish message to {Topic}", topic);
             throw;
+        }
+    }
+
+    public Task<bool> IsConnectedAsync()
+    {
+        try
+        {
+            using var adminClient = new AdminClientBuilder(new AdminClientConfig 
+            { 
+                BootstrapServers = _bootstrapServers,
+                SocketTimeoutMs = 5000
+            }).Build();
+            
+            var metadata = adminClient.GetMetadata(TimeSpan.FromSeconds(5));
+            return Task.FromResult(metadata.Brokers.Count > 0);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Kafka connection check failed");
+            return Task.FromResult(false);
         }
     }
 

--- a/electrostoreCRON/Kafka/Consumers/KafkaCronJobEventsConsumer.cs
+++ b/electrostoreCRON/Kafka/Consumers/KafkaCronJobEventsConsumer.cs
@@ -30,8 +30,8 @@ public class KafkaCronJobEventsConsumer : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var bootstrapServers = _configuration["Kafka:BootstrapServers"] ?? "kafka:9092";
-        var groupId          = _configuration["Kafka:CronConsumerGroupId"] ?? "cron-service-events";
+        var bootstrapServers = _configuration.GetSection("Kafka:BootstrapServers").Value ?? "kafka:9092";
+        var groupId = _configuration.GetSection("Kafka:ConsumerGroupId").Value ?? "cron-service-events";
 
         var config = new ConsumerConfig
         {
@@ -54,7 +54,7 @@ public class KafkaCronJobEventsConsumer : BackgroundService
                 ConsumeResult<string, string>? result = null;
                 try
                 {
-                    result = consumer.Consume(stoppingToken);
+                    result = await Task.Run(() => consumer.Consume(stoppingToken), stoppingToken);
                 }
                 catch (OperationCanceledException)
                 {

--- a/electrostoreCRON/Properties/launchSettings.json
+++ b/electrostoreCRON/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:62395;http://localhost:62396"
+      "applicationUrl": "http://localhost:5234"
     }
   }
 }

--- a/electrostoreCRON/electrostoreCRON.csproj
+++ b/electrostoreCRON/electrostoreCRON.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <RootNamespace>ElectrostoreCRON</RootNamespace>
-    <AssemblyName>electrostoreCRON</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/electrostoreIA/Kafka/Consumers/KafkaIaTrainConsumer.cs
+++ b/electrostoreIA/Kafka/Consumers/KafkaIaTrainConsumer.cs
@@ -35,8 +35,8 @@ public class KafkaIaTrainConsumer : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var bootstrapServers = _configuration.GetValue<string>("Kafka:BootstrapServers") ?? "kafka:9092";
-        var groupId = _configuration.GetValue<string>("Kafka:ConsumerGroupId") ?? "ia-service";
+        var bootstrapServers = _configuration.GetSection("Kafka:BootstrapServers").Value ?? "kafka:9092";
+        var groupId = _configuration.GetSection("Kafka:ConsumerGroupId").Value ?? "ia-service";
 
         var config = new ConsumerConfig
         {
@@ -71,7 +71,7 @@ public class KafkaIaTrainConsumer : BackgroundService
                 ConsumeResult<string, string>? result = null;
                 try
                 {
-                    result = consumer.Consume(TimeSpan.FromSeconds(2));
+                    result = await Task.Run(() => consumer.Consume(stoppingToken), stoppingToken);
                 }
                 catch (OperationCanceledException)
                 {

--- a/electrostoreIA/Program.cs
+++ b/electrostoreIA/Program.cs
@@ -9,6 +9,7 @@ using ElectrostoreIA.Grpc;
 using ElectrostoreIA.Grpc.Services;
 using ElectrostoreIA.Kafka.Consumers;
 using ElectrostoreIA.Kafka.Producer;
+using Microsoft.AspNetCore.Mvc;
 using Minio;
 
 namespace ElectrostoreIA;
@@ -57,7 +58,7 @@ public partial class Program
         app.UseStaticFiles();
         CreateRequiredDirectories();
 
-        app.MapGet("/health", (ModelTrainerService trainerService, ConfigCacheService configCache) =>
+        app.MapGet("/health", ([FromServices] IModelTrainerService trainerService, [FromServices] IConfigCacheService configCache) =>
             Results.Ok(new
             {
                 status = configCache.DemoMode ? "demo" : "healthy",

--- a/electrostoreIA/Properties/launchSettings.json
+++ b/electrostoreIA/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:61742;http://localhost:61743"
+      "applicationUrl": "http://localhost:5234"
     }
   }
 }

--- a/electrostoreIA/config/appsettings.Development.json
+++ b/electrostoreIA/config/appsettings.Development.json
@@ -28,10 +28,10 @@
     "Secure": false
   },
   "Kafka": {
-    "BootstrapServers": "<your-kafka-bootstrap-servers>",
+    "BootstrapServers": "192.168.1.101:9092",
     "ConsumerGroupId": "ia-service"
   },
-  "ApiServiceGrpcUrl": "http://electrostoreAPI:5001",
+  "ApiServiceGrpcUrl": "http://192.168.1.101:5001",
   "Vault": {
     "Enable": false,
     "Addr": "http://vault:8200",

--- a/electrostoreIA/config/appsettings.Development.json
+++ b/electrostoreIA/config/appsettings.Development.json
@@ -28,10 +28,10 @@
     "Secure": false
   },
   "Kafka": {
-    "BootstrapServers": "192.168.1.101:9092",
+    "BootstrapServers": "<your-kafka-bootstrap-servers>",
     "ConsumerGroupId": "ia-service"
   },
-  "ApiServiceGrpcUrl": "http://192.168.1.101:5001",
+  "ApiServiceGrpcUrl": "http://electrostoreAPI:5001",
   "Vault": {
     "Enable": false,
     "Addr": "http://vault:8200",

--- a/electrostoreIA/electrostoreIA.csproj
+++ b/electrostoreIA/electrostoreIA.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <RootNamespace>ElectrostoreIA</RootNamespace>
-    <AssemblyName>electrostoreIA</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/electrostoreNOTIF/Kafka/Consumers/KafkaNotifConsumer.cs
+++ b/electrostoreNOTIF/Kafka/Consumers/KafkaNotifConsumer.cs
@@ -36,8 +36,8 @@ public class KafkaNotifConsumer : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var bootstrapServers = _configuration["Kafka:BootstrapServers"] ?? "kafka:9092";
-        var groupId = _configuration["Kafka:ConsumerGroupId"] ?? "notif-service";
+        var bootstrapServers = _configuration.GetSection("Kafka:BootstrapServers").Value ?? "kafka:9092";
+        var groupId = _configuration.GetSection("Kafka:ConsumerGroupId").Value ?? "notif-service";
         var config = new ConsumerConfig
         {
             BootstrapServers = bootstrapServers,
@@ -74,7 +74,7 @@ public class KafkaNotifConsumer : BackgroundService
                 ConsumeResult<string, string>? result = null;
                 try
                 {
-                    result = consumer.Consume(TimeSpan.FromSeconds(2));
+                    result = await Task.Run(() => consumer.Consume(stoppingToken), stoppingToken);
                 }
                 catch (OperationCanceledException)
                 {

--- a/electrostoreNOTIF/Properties/launchSettings.json
+++ b/electrostoreNOTIF/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:61623;http://localhost:61624"
+      "applicationUrl": "http://localhost:5234"
     }
   }
 }

--- a/electrostoreNOTIF/Services/EmailSenderService/EmailSenderService.cs
+++ b/electrostoreNOTIF/Services/EmailSenderService/EmailSenderService.cs
@@ -22,17 +22,36 @@ public class EmailSenderService : IEmailSenderService
             return;
         }
 
+        // Validate recipient address
+        if (string.IsNullOrWhiteSpace(to))
+        {
+            _logger.LogError("Recipient e-mail address is null or empty");
+            throw new ArgumentException("Recipient e-mail address cannot be null or empty", nameof(to));
+        }
+
         var host = _configuration["SMTP:Host"] ?? throw new InvalidOperationException("SMTP:Host configuration is missing");
         var port = int.Parse(_configuration["SMTP:Port"] ?? "587");
         var username = _configuration["SMTP:Username"];
         var password = _configuration["SMTP:Password"];
         var from = _configuration["SMTP:From"] ?? username ?? "noreply@electrostore.local";
 
+        // Validate sender address
+        if (string.IsNullOrWhiteSpace(from))
+        {
+            _logger.LogError("Sender e-mail address is null or empty");
+            throw new InvalidOperationException("SMTP:From configuration is missing and no username is configured");
+        }
+
         using var client = new SmtpClient(host, port)
         {
-            Credentials = new NetworkCredential(username, password),
             EnableSsl = true
         };
+
+        // Only set credentials if username and password are provided
+        if (!string.IsNullOrWhiteSpace(username) && !string.IsNullOrWhiteSpace(password))
+        {
+            client.Credentials = new NetworkCredential(username, password);
+        }
 
         var message = new MailMessage(from, to, subject, body) { IsBodyHtml = true };
 

--- a/electrostoreNOTIF/Services/WebPushService/WebPushService.cs
+++ b/electrostoreNOTIF/Services/WebPushService/WebPushService.cs
@@ -5,12 +5,14 @@ namespace ElectrostoreNOTIF.Services.WebPushService;
 
 public class WebPushService : IWebPushService
 {
+    private readonly IConfiguration _configuration;
     private readonly ILogger<WebPushService> _logger;
     private readonly WebPushClient _client;
     private readonly VapidDetails _vapid;
 
     public WebPushService(IConfiguration configuration, ILogger<WebPushService> logger)
     {
+        _configuration = configuration;
         _logger = logger;
         var publicKey = configuration["VAPID:PublicKey"] ?? throw new InvalidOperationException("VAPID:PublicKey is not configured.");
         var privateKey = configuration["VAPID:PrivateKey"] ?? throw new InvalidOperationException("VAPID:PrivateKey is not configured.");
@@ -21,6 +23,13 @@ public class WebPushService : IWebPushService
 
     public async Task SendAsync(string endpoint, string p256dh, string auth, string title, string body, Dictionary<string, string>? data = null)
     {
+
+        if (!bool.TryParse(_configuration["VAPID:Enable"], out var isEnabled) || !isEnabled)
+        {
+            _logger.LogDebug("VAPID disabled — push notification ignored for {Endpoint}", endpoint);
+            return;
+        }
+
         var payload = JsonSerializer.Serialize(new
         {
             title,

--- a/electrostoreNOTIF/electrostoreNOTIF.csproj
+++ b/electrostoreNOTIF/electrostoreNOTIF.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <RootNamespace>ElectrostoreNOTIF</RootNamespace>
-    <AssemblyName>electrostoreNOTIF</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/electrostoreWORKER/Kafka/Consumers/KafkaIaStatusConsumer.cs
+++ b/electrostoreWORKER/Kafka/Consumers/KafkaIaStatusConsumer.cs
@@ -28,8 +28,8 @@ public class KafkaIaStatusConsumer : BackgroundService
 
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        var bootstrapServers = _configuration["Kafka:BootstrapServers"] ?? "kafka:9092";
-        var groupId          = _configuration["Kafka:ConsumerGroupId"]  ?? "worker-service";
+        var bootstrapServers = _configuration.GetSection("Kafka:BootstrapServers").Value ?? "kafka:9092";
+        var groupId = _configuration.GetSection("Kafka:ConsumerGroupId").Value ?? "worker-service";
 
         var config = new ConsumerConfig
         {
@@ -68,7 +68,7 @@ public class KafkaIaStatusConsumer : BackgroundService
                 ConsumeResult<string, string>? result = null;
                 try
                 {
-                    result = consumer.Consume(TimeSpan.FromSeconds(2));
+                    result = await Task.Run(() => consumer.Consume(stoppingToken), stoppingToken);
                 }
                 catch (OperationCanceledException)
                 {

--- a/electrostoreWORKER/Properties/launchSettings.json
+++ b/electrostoreWORKER/Properties/launchSettings.json
@@ -6,7 +6,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:52334;http://localhost:52335"
+      "applicationUrl": "http://localhost:5234"
     }
   }
 }

--- a/electrostoreWORKER/electrostoreWORKER.csproj
+++ b/electrostoreWORKER/electrostoreWORKER.csproj
@@ -4,8 +4,6 @@
     <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <RootNamespace>ElectrostoreWORKER</RootNamespace>
-    <AssemblyName>electrostoreWORKER</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates across generator scripts, Kafka producer/consumers, notif/email services and project settings.

- docs/generator/js/generators.js: Add ia-data volume to compose, remove legacy KAFKA_CREATE_TOPICS env, add runtime Kafka initialization, readiness checks and topic creation for non-legacy setups; adjust PowerShell/ bash flows to conditionally configure Kafka and IA S3 keys.
- electrostoreAPI: Add IKafkaProducerService.IsConnectedAsync and implement a broker connectivity check in KafkaProducerService (uses AdminClient metadata and configurable bootstrap servers).
- Kafka consumers (CRON, IA, NOTIF, WORKER): Read Kafka settings via configuration sections, switch consumer.Consume calls to run on a Task.Run with cancellation token to avoid blocking, and harmonize ConsumerGroupId keys.
- electrostoreIA: add MVC FromServices DI annotations to health endpoint and add using Microsoft.AspNetCore.Mvc; update development appsettings with concrete Kafka and API urls.
- electrostoreNOTIF: strengthen EmailSenderService with recipient/sender validation and only set SMTP credentials when present; WebPushService now checks VAPID:Enable before sending and stores IConfiguration for that check.
- launchSettings.json: normalize applicationUrl for several services to http://localhost:5234.
- csproj files: remove explicit RootNamespace and AssemblyName entries from several projects.

Overall these changes improve Kafka readiness and topic management, make consumers more cancellation-friendly, harden notification sending logic, and simplify local launch settings.