### PR TITLE
feat: add itemHistory

### DIFF
--- a/electrostoreAPI/ApplicationDbContext.cs
+++ b/electrostoreAPI/ApplicationDbContext.cs
@@ -23,6 +23,7 @@ public class ApplicationDbContext : DbContext
     public DbSet<ElectrostoreAPI.Models.Imgs> Imgs { get; set; }
     public DbSet<ElectrostoreAPI.Models.Items> Items { get; set; }
     public DbSet<ElectrostoreAPI.Models.ItemsBoxs> ItemsBoxs { get; set; }
+    public DbSet<ElectrostoreAPI.Models.ItemsHistory> ItemsHistory { get; set; }
     public DbSet<ElectrostoreAPI.Models.ItemsDocuments> ItemsDocuments { get; set; }
     public DbSet<ElectrostoreAPI.Models.ItemsTags> ItemsTags { get; set; }
     public DbSet<ElectrostoreAPI.Models.JwiAccessTokens> JwiAccessTokens { get; set; }
@@ -91,5 +92,23 @@ public class ApplicationDbContext : DbContext
 
         modelBuilder.Entity<StoresTags>()
             .HasKey(st => new { st.id_store, st.id_tag });
+
+        modelBuilder.Entity<ItemsHistory>()
+            .HasOne(h => h.Item)
+            .WithMany()
+            .HasForeignKey(h => h.id_item)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        modelBuilder.Entity<ItemsHistory>()
+            .HasOne(h => h.Box)
+            .WithMany()
+            .HasForeignKey(h => h.id_box)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        modelBuilder.Entity<ItemsHistory>()
+            .HasOne(h => h.User)
+            .WithMany()
+            .HasForeignKey(h => h.id_user)
+            .OnDelete(DeleteBehavior.SetNull);
     }
 }

--- a/electrostoreAPI/Controllers/ItemController.cs
+++ b/electrostoreAPI/Controllers/ItemController.cs
@@ -22,7 +22,7 @@ namespace ElectrostoreAPI.Controllers
         [HttpGet]
         [Authorize(Policy = "AccessToken")]
         public async Task<ActionResult<PaginatedResponseDto<ReadExtendedItemDto>>> GetItems([FromQuery] int limit = 100, [FromQuery] int offset = 0,
-        [FromQuery, SwaggerParameter(Description = "(Optional) Fields to expand. Possible values: 'item_tags', 'item_boxs', 'command_items', 'projet_items', 'item_documents'. Multiple values can be specified by separating them with ','.")] List<string>? expand = null,
+        [FromQuery, SwaggerParameter(Description = "(Optional) Fields to expand. Possible values: 'item_tags', 'item_boxs', 'command_items', 'projet_items', 'item_documents', 'item_history'. Multiple values can be specified by separating them with ','.")] List<string>? expand = null,
         [FromQuery, SwaggerParameter(Description = "(Optional) Fields to select list of ID to research in the base. Multiple values can be specified by separating them with ','.")] List<int>? idResearch = null,
         [FromQuery, SwaggerParameter(Description = "(Optional) RSQL string to filter results. Example: 'nom_item=like=example'.")] string? filter = null,
         [FromQuery, SwaggerParameter(Description = "(Optional) Sort string to order results. Example: 'nom_item,asc' or 'nom_item,desc'.")] string? sort = null)
@@ -36,7 +36,7 @@ namespace ElectrostoreAPI.Controllers
         [HttpGet("{id_item}")]
         [Authorize(Policy = "AccessToken")]
         public async Task<ActionResult<ReadExtendedItemDto>> GetItemById([FromRoute] int id_item,
-        [FromQuery, SwaggerParameter(Description = "(Optional) Fields to expand. Possible values: 'item_tags', 'item_boxs', 'command_items', 'projet_items', 'item_documents'. Multiple values can be specified by separating them with ','.")] List<string>? expand = null)
+        [FromQuery, SwaggerParameter(Description = "(Optional) Fields to expand. Possible values: 'item_tags', 'item_boxs', 'command_items', 'projet_items', 'item_documents', 'item_history'. Multiple values can be specified by separating them with ','.")] List<string>? expand = null)
         {
             var item = await _itemService.GetItemById(id_item, expand);
             return Ok(item);

--- a/electrostoreAPI/Controllers/ItemHistoryController.cs
+++ b/electrostoreAPI/Controllers/ItemHistoryController.cs
@@ -1,0 +1,59 @@
+using ElectrostoreAPI.Dto;
+using ElectrostoreAPI.Extensions;
+using ElectrostoreAPI.Services.ItemHistoryService;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace ElectrostoreAPI.Controllers
+{
+    [ApiController]
+    public class ItemHistoryController : ControllerBase
+    {
+        private readonly IItemHistoryService _itemHistoryService;
+
+        public ItemHistoryController(IItemHistoryService itemHistoryService)
+        {
+            _itemHistoryService = itemHistoryService;
+        }
+
+        [HttpGet("api/item/{id_item}/history")]
+        [Authorize(Policy = "AccessToken")]
+        public async Task<ActionResult<PaginatedResponseDto<ReadExtendedItemHistoryDto>>> GetItemHistoryByItemId(
+            [FromRoute] int id_item,
+            [FromQuery] int limit = 100,
+            [FromQuery] int offset = 0,
+            [FromQuery, SwaggerParameter(Description = "(Optional) RSQL string to filter results.")] string? filter = null,
+            [FromQuery, SwaggerParameter(Description = "(Optional) Sort string. Example: 'created_at,desc'.")] string? sort = null)
+        {
+            var rsqlDto = ParserExtensions.ParseFilter(filter ?? string.Empty);
+            var sortDto = ParserExtensions.ParseSort(sort ?? string.Empty);
+            var history = await _itemHistoryService.GetItemHistoryByItemId(id_item, limit, offset, rsqlDto, sortDto);
+            return Ok(history);
+        }
+
+        [HttpGet("api/item/{id_item}/history/{id_history}")]
+        [Authorize(Policy = "AccessToken")]
+        public async Task<ActionResult<ReadExtendedItemHistoryDto>> GetItemHistoryById(
+            [FromRoute] int id_item,
+            [FromRoute] int id_history)
+        {
+            var history = await _itemHistoryService.GetItemHistoryById(id_history, id_item);
+            return Ok(history);
+        }
+
+        [HttpGet("api/item/history")]
+        [Authorize(Policy = "AccessToken")]
+        public async Task<ActionResult<PaginatedResponseDto<ReadExtendedItemHistoryDto>>> GetItemsHistory(
+            [FromQuery] int limit = 100,
+            [FromQuery] int offset = 0,
+            [FromQuery, SwaggerParameter(Description = "(Optional) RSQL string to filter results.")] string? filter = null,
+            [FromQuery, SwaggerParameter(Description = "(Optional) Sort string. Example: 'created_at,desc'.")] string? sort = null)
+        {
+            var rsqlDto = ParserExtensions.ParseFilter(filter ?? string.Empty);
+            var sortDto = ParserExtensions.ParseSort(sort ?? string.Empty);
+            var history = await _itemHistoryService.GetItemsHistory(limit, offset, rsqlDto, sortDto);
+            return Ok(history);
+        }
+    }
+}

--- a/electrostoreAPI/DTO/ItemDto.cs
+++ b/electrostoreAPI/DTO/ItemDto.cs
@@ -27,6 +27,7 @@ public record ReadExtendedItemDto : ReadItemDto
     public IEnumerable<ReadCommandItemDto>? command_items { get; init; }
     public IEnumerable<ReadProjetItemDto>? projet_items { get; init; }
     public IEnumerable<ReadItemDocumentDto>? item_documents { get; init; }
+    public IEnumerable<ReadItemHistoryDto>? item_history { get; init; }
 }
 public record CreateItemDto
 {

--- a/electrostoreAPI/DTO/ItemHistoryDto.cs
+++ b/electrostoreAPI/DTO/ItemHistoryDto.cs
@@ -1,0 +1,25 @@
+using ElectrostoreAPI.Enums;
+
+namespace ElectrostoreAPI.Dto;
+
+public record ReadItemHistoryDto
+{
+    public int id_item_history { get; init; }
+    public int? id_item { get; init; }
+    public int? id_box { get; init; }
+    public int? id_user { get; init; }
+    public ItemHistoryType type { get; init; }
+    public int? quantity_change { get; init; }
+    public int? old_quantity { get; init; }
+    public int? new_quantity { get; init; }
+    public string? notes { get; init; }
+    public DateTime created_at { get; init; }
+    public DateTime updated_at { get; init; }
+}
+
+public record ReadExtendedItemHistoryDto : ReadItemHistoryDto
+{
+    public ReadItemDto? item { get; init; }
+    public ReadBoxDto? box { get; init; }
+    public ReadUserDto? user { get; init; }
+}

--- a/electrostoreAPI/Enums/ItemHistoryType.cs
+++ b/electrostoreAPI/Enums/ItemHistoryType.cs
@@ -1,0 +1,11 @@
+namespace ElectrostoreAPI.Enums;
+
+public enum ItemHistoryType
+{
+    ItemCreated,
+    ItemUpdated,
+    ItemDeleted,
+    StockAdded,
+    StockRemoved,
+    StockUpdated
+}

--- a/electrostoreAPI/Mapper.cs
+++ b/electrostoreAPI/Mapper.cs
@@ -69,6 +69,12 @@ public class MappingProfile : Profile
         CreateMap<Items, ReadItemDto>();
         CreateMap<Items, ReadExtendedItemDto>();
 
+        CreateMap<ItemsHistory, ReadItemHistoryDto>();
+        CreateMap<ItemsHistory, ReadExtendedItemHistoryDto>()
+            .ForMember(dest => dest.item, opt => opt.MapFrom(src => src.Item))
+            .ForMember(dest => dest.box, opt => opt.MapFrom(src => src.Box))
+            .ForMember(dest => dest.user, opt => opt.MapFrom(src => src.User));
+
         CreateMap<CreateItemTagDto, ItemsTags>();
         CreateMap<ItemsTags, ReadItemTagDto>();
         CreateMap<ItemsTags, ReadExtendedItemTagDto>()

--- a/electrostoreAPI/Migrations/20260624092708_AddItemsHistory.Designer.cs
+++ b/electrostoreAPI/Migrations/20260624092708_AddItemsHistory.Designer.cs
@@ -4,16 +4,19 @@ using ElectrostoreAPI;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace ElectrostoreAPI.Migrations
+namespace electrostoreAPI.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260624092708_AddItemsHistory")]
+    partial class AddItemsHistory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/electrostoreAPI/Migrations/20260624092708_AddItemsHistory.cs
+++ b/electrostoreAPI/Migrations/20260624092708_AddItemsHistory.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace electrostoreAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddItemsHistory : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ItemsHistory",
+                columns: table => new
+                {
+                    id_item_history = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    id_item = table.Column<int>(type: "int", nullable: true),
+                    id_box = table.Column<int>(type: "int", nullable: true),
+                    id_user = table.Column<int>(type: "int", nullable: true),
+                    type = table.Column<int>(type: "int", nullable: false),
+                    quantity_change = table.Column<int>(type: "int", nullable: true),
+                    old_quantity = table.Column<int>(type: "int", nullable: true),
+                    new_quantity = table.Column<int>(type: "int", nullable: true),
+                    notes = table.Column<string>(type: "varchar(500)", maxLength: 500, nullable: true)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    created_at = table.Column<DateTime>(type: "datetime(6)", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "datetime(6)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ItemsHistory", x => x.id_item_history);
+                    table.ForeignKey(
+                        name: "FK_ItemsHistory_Boxs_id_box",
+                        column: x => x.id_box,
+                        principalTable: "Boxs",
+                        principalColumn: "id_box",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_ItemsHistory_Items_id_item",
+                        column: x => x.id_item,
+                        principalTable: "Items",
+                        principalColumn: "id_item",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_ItemsHistory_Users_id_user",
+                        column: x => x.id_user,
+                        principalTable: "Users",
+                        principalColumn: "id_user",
+                        onDelete: ReferentialAction.SetNull);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ItemsHistory_id_box",
+                table: "ItemsHistory",
+                column: "id_box");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ItemsHistory_id_item",
+                table: "ItemsHistory",
+                column: "id_item");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ItemsHistory_id_user",
+                table: "ItemsHistory",
+                column: "id_user");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ItemsHistory");
+        }
+    }
+}

--- a/electrostoreAPI/Models/Items.cs
+++ b/electrostoreAPI/Models/Items.cs
@@ -29,5 +29,6 @@ public class Items : BaseEntity
     public ICollection<ItemsBoxs> ItemsBoxs { get; set; } = new List<ItemsBoxs>();
     public ICollection<ItemsDocuments> ItemsDocuments { get; set; } = new List<ItemsDocuments>();
     public ICollection<ItemsTags> ItemsTags { get; set; } = new List<ItemsTags>();
+    public ICollection<ItemsHistory> ItemsHistory { get; set; } = new List<ItemsHistory>();
     public ICollection<ProjetsItems> ProjetsItems { get; set; } = new List<ProjetsItems>();
 }

--- a/electrostoreAPI/Models/ItemsHistory.cs
+++ b/electrostoreAPI/Models/ItemsHistory.cs
@@ -1,0 +1,36 @@
+using ElectrostoreAPI.Dto;
+using ElectrostoreAPI.Enums;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ElectrostoreAPI.Models;
+
+public class ItemsHistory : BaseEntity
+{
+    [Key]
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int id_item_history { get; set; }
+
+    public int? id_item { get; set; }
+    [ForeignKey("id_item")]
+    public Items? Item { get; set; }
+
+    public int? id_box { get; set; }
+    [ForeignKey("id_box")]
+    public Boxs? Box { get; set; }
+
+    public int? id_user { get; set; }
+    [ForeignKey("id_user")]
+    public Users? User { get; set; }
+
+    public ItemHistoryType type { get; set; }
+
+    public int? quantity_change { get; set; }
+
+    public int? old_quantity { get; set; }
+
+    public int? new_quantity { get; set; }
+
+    [MaxLength(Constants.MaxDescriptionLength)]
+    public string? notes { get; set; }
+}

--- a/electrostoreAPI/Program.cs
+++ b/electrostoreAPI/Program.cs
@@ -20,6 +20,7 @@ using ElectrostoreAPI.Services.IAService;
 using ElectrostoreAPI.Services.ImgService;
 using ElectrostoreAPI.Services.ItemBoxService;
 using ElectrostoreAPI.Services.ItemDocumentService;
+using ElectrostoreAPI.Services.ItemHistoryService;
 using ElectrostoreAPI.Services.ItemService;
 using ElectrostoreAPI.Services.ItemTagService;
 using ElectrostoreAPI.Services.JwiService;
@@ -344,6 +345,7 @@ public partial class Program
         builder.Services.AddScoped<IImgService, ImgService>();
         builder.Services.AddScoped<IItemBoxService, ItemBoxService>();
         builder.Services.AddScoped<IItemDocumentService, ItemDocumentService>();
+        builder.Services.AddScoped<IItemHistoryService, ItemHistoryService>();
         builder.Services.AddScoped<IItemService, ItemService>();
         builder.Services.AddScoped<IItemTagService, ItemTagService>();
         builder.Services.AddScoped<ILedService, LedService>();

--- a/electrostoreAPI/Services/ItemBoxService/ItemBoxService.cs
+++ b/electrostoreAPI/Services/ItemBoxService/ItemBoxService.cs
@@ -1,7 +1,9 @@
 using AutoMapper;
 using ElectrostoreAPI.Dto;
+using ElectrostoreAPI.Enums;
 using ElectrostoreAPI.Extensions;
 using ElectrostoreAPI.Models;
+using ElectrostoreAPI.Services.ItemHistoryService;
 using Microsoft.EntityFrameworkCore;
 using System.Linq.Expressions;
 
@@ -11,11 +13,13 @@ public class ItemBoxService : IItemBoxService
 {
     private readonly IMapper _mapper;
     private readonly ApplicationDbContext _context;
+    private readonly IItemHistoryService _itemHistoryService;
 
-    public ItemBoxService(IMapper mapper, ApplicationDbContext context)
+    public ItemBoxService(IMapper mapper, ApplicationDbContext context, IItemHistoryService itemHistoryService)
     {
         _mapper = mapper;
         _context = context;
+        _itemHistoryService = itemHistoryService;
     }
 
     public async Task<PaginatedResponseDto<ReadExtendedItemBoxDto>> GetItemsBoxsByBoxId(int boxId, int limit = 100, int offset = 0,
@@ -174,12 +178,15 @@ public class ItemBoxService : IItemBoxService
         var newItemBox = _mapper.Map<ItemsBoxs>(itemBoxDto);
         _context.ItemsBoxs.Add(newItemBox);
         await _context.SaveChangesAsync();
+        await _itemHistoryService.LogHistory(newItemBox.id_item, newItemBox.id_box, ItemHistoryType.StockAdded,
+            oldQuantity: null, newQuantity: newItemBox.qte_item_box);
         return _mapper.Map<ReadItemBoxDto>(newItemBox);
     }
 
     public async Task<ReadItemBoxDto> UpdateItemBox(int itemId, int boxId, UpdateItemBoxDto itemBoxDto)
     {
         var itemBoxToUpdate = await _context.ItemsBoxs.FindAsync(itemId, boxId) ?? throw new KeyNotFoundException($"ItemBox with id '{itemId}' and boxId '{boxId}' not found");
+        var oldQte = itemBoxToUpdate.qte_item_box;
         if (itemBoxDto.qte_item_box is not null)
         {
             itemBoxToUpdate.qte_item_box = itemBoxDto.qte_item_box.Value;
@@ -190,12 +197,22 @@ public class ItemBoxService : IItemBoxService
             itemBoxToUpdate.seuil_max_item_item_box = itemBoxDto.seuil_max_item_item_box.Value;
         }
         await _context.SaveChangesAsync();
+        if (itemBoxDto.qte_item_box is not null)
+        {
+            var historyType = itemBoxToUpdate.qte_item_box > oldQte ? ItemHistoryType.StockAdded
+                : itemBoxToUpdate.qte_item_box < oldQte ? ItemHistoryType.StockRemoved
+                : ItemHistoryType.StockUpdated;
+            await _itemHistoryService.LogHistory(itemId, boxId, historyType,
+                oldQuantity: oldQte, newQuantity: itemBoxToUpdate.qte_item_box);
+        }
         return _mapper.Map<ReadItemBoxDto>(itemBoxToUpdate);
     }
 
     public async Task DeleteItemBox(int itemId, int boxId)
     {
         var itemBoxToDelete = await _context.ItemsBoxs.FindAsync(itemId, boxId) ?? throw new KeyNotFoundException($"ItemBox with id '{itemId}' and boxId '{boxId}' not found");
+        await _itemHistoryService.LogHistory(itemBoxToDelete.id_item, itemBoxToDelete.id_box, ItemHistoryType.StockRemoved,
+            oldQuantity: itemBoxToDelete.qte_item_box, newQuantity: null);
         _context.ItemsBoxs.Remove(itemBoxToDelete);
         await _context.SaveChangesAsync();
     }

--- a/electrostoreAPI/Services/ItemHistoryService/IItemHistoryService.cs
+++ b/electrostoreAPI/Services/ItemHistoryService/IItemHistoryService.cs
@@ -1,0 +1,18 @@
+using ElectrostoreAPI.Dto;
+using ElectrostoreAPI.Enums;
+
+namespace ElectrostoreAPI.Services.ItemHistoryService;
+
+public interface IItemHistoryService
+{
+    Task<PaginatedResponseDto<ReadExtendedItemHistoryDto>> GetItemHistoryByItemId(int itemId, int limit = 100, int offset = 0,
+        List<FilterDto>? rsql = null, SorterDto? sort = null);
+
+    Task<ReadExtendedItemHistoryDto> GetItemHistoryById(int id, int itemId);
+
+    Task<PaginatedResponseDto<ReadExtendedItemHistoryDto>> GetItemsHistory(int limit = 100, int offset = 0,
+        List<FilterDto>? rsql = null, SorterDto? sort = null);
+
+    Task LogHistory(int? itemId, int? boxId, ItemHistoryType type,
+        int? oldQuantity = null, int? newQuantity = null, string? notes = null);
+}

--- a/electrostoreAPI/Services/ItemHistoryService/ItemHistoryService.cs
+++ b/electrostoreAPI/Services/ItemHistoryService/ItemHistoryService.cs
@@ -1,0 +1,178 @@
+using AutoMapper;
+using ElectrostoreAPI.Dto;
+using ElectrostoreAPI.Enums;
+using ElectrostoreAPI.Extensions;
+using ElectrostoreAPI.Models;
+using Microsoft.EntityFrameworkCore;
+using System.Linq.Expressions;
+using System.Security.Claims;
+
+namespace ElectrostoreAPI.Services.ItemHistoryService;
+
+public class ItemHistoryService : IItemHistoryService
+{
+    private readonly IMapper _mapper;
+    private readonly ApplicationDbContext _context;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public ItemHistoryService(IMapper mapper, ApplicationDbContext context, IHttpContextAccessor httpContextAccessor)
+    {
+        _mapper = mapper;
+        _context = context;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async Task<PaginatedResponseDto<ReadExtendedItemHistoryDto>> GetItemHistoryByItemId(int itemId, int limit = 100, int offset = 0,
+        List<FilterDto>? rsql = null, SorterDto? sort = null)
+    {
+        if (!await _context.Items.AnyAsync(i => i.id_item == itemId))
+        {
+            throw new KeyNotFoundException($"Item with id '{itemId}' not found");
+        }
+        var query = _context.ItemsHistory.AsQueryable();
+        var filterResult = default(Expression<Func<ItemsHistory, bool>>);
+        rsql ??= [];
+        rsql.Add(new FilterDto { Field = "id_item", SearchType = "eq", Value = itemId.ToString() });
+        if (rsql != null && rsql.Count > 0)
+        {
+            (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<ItemsHistory>(rsql);
+            query = query.Where(filterResult);
+        }
+        if (!string.IsNullOrEmpty(sort?.Field))
+        {
+            var sortResult = RsqlParserExtensions.ToSortExpression<ItemsHistory>(sort);
+            if (sortResult.Item1 != null)
+            {
+                query = sortResult.Item2 == "asc" ? query.OrderBy(sortResult.Item1) : query.OrderByDescending(sortResult.Item1);
+            }
+            else
+            {
+                sort = new SorterDto { Field = "id_item_history", Order = "desc" };
+                query = query.OrderByDescending(h => h.id_item_history);
+            }
+        }
+        else
+        {
+            query = query.OrderByDescending(h => h.id_item_history);
+        }
+        query = query.Skip(offset).Take(limit);
+        var history = await query
+            .Include(h => h.Item)
+            .Include(h => h.Box)
+            .Include(h => h.User)
+            .ToListAsync();
+        return new PaginatedResponseDto<ReadExtendedItemHistoryDto>
+        {
+            data = _mapper.Map<List<ReadExtendedItemHistoryDto>>(history),
+            pagination = new PaginationDto
+            {
+                offset = offset,
+                limit = limit,
+                total = await _context.ItemsHistory.CountAsync(filterResult ?? (h => h.id_item == itemId)),
+                nextOffset = offset + limit,
+                hasMore = await _context.ItemsHistory.Skip(offset + limit).AnyAsync(filterResult ?? (h => h.id_item == itemId))
+            },
+            filters = rsql,
+            sort = sort != null ? [sort] : null
+        };
+    }
+
+    public async Task<ReadExtendedItemHistoryDto> GetItemHistoryById(int id, int itemId)
+    {
+        var history = await _context.ItemsHistory
+            .Include(h => h.Item)
+            .Include(h => h.Box)
+            .Include(h => h.User)
+            .FirstOrDefaultAsync(h => h.id_item_history == id && h.id_item == itemId)
+            ?? throw new KeyNotFoundException($"ItemHistory with id '{id}' not found for Item with id '{itemId}'");
+        return _mapper.Map<ReadExtendedItemHistoryDto>(history);
+    }
+
+    public async Task<PaginatedResponseDto<ReadExtendedItemHistoryDto>> GetItemsHistory(int limit = 100, int offset = 0,
+        List<FilterDto>? rsql = null, SorterDto? sort = null)
+    {
+        var query = _context.ItemsHistory.AsQueryable();
+        var filterResult = default(Expression<Func<ItemsHistory, bool>>);
+        if (rsql != null && rsql.Count > 0)
+        {
+            (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<ItemsHistory>(rsql);
+            query = query.Where(filterResult);
+        }
+        if (!string.IsNullOrEmpty(sort?.Field))
+        {
+            var sortResult = RsqlParserExtensions.ToSortExpression<ItemsHistory>(sort);
+            if (sortResult.Item1 != null)
+            {
+                query = sortResult.Item2 == "asc" ? query.OrderBy(sortResult.Item1) : query.OrderByDescending(sortResult.Item1);
+            }
+            else
+            {
+                sort = new SorterDto { Field = "id_item_history", Order = "desc" };
+                query = query.OrderByDescending(h => h.id_item_history);
+            }
+        }
+        else
+        {
+            query = query.OrderByDescending(h => h.id_item_history);
+        }
+        query = query.Skip(offset).Take(limit);
+        var history = await query
+            .Include(h => h.Item)
+            .Include(h => h.Box)
+            .Include(h => h.User)
+            .ToListAsync();
+        return new PaginatedResponseDto<ReadExtendedItemHistoryDto>
+        {
+            data = _mapper.Map<List<ReadExtendedItemHistoryDto>>(history),
+            pagination = new PaginationDto
+            {
+                offset = offset,
+                limit = limit,
+                total = await _context.ItemsHistory.CountAsync(filterResult ?? (h => true)),
+                nextOffset = offset + limit,
+                hasMore = await _context.ItemsHistory.Skip(offset + limit).AnyAsync(filterResult ?? (h => true))
+            },
+            filters = rsql,
+            sort = sort != null ? [sort] : null
+        };
+    }
+
+    public async Task LogHistory(int? itemId, int? boxId, ItemHistoryType type,
+        int? oldQuantity = null, int? newQuantity = null, string? notes = null)
+    {
+        int? userId = null;
+        var userIdClaim = _httpContextAccessor.HttpContext?.User?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (int.TryParse(userIdClaim, out var parsedUserId))
+        {
+            userId = parsedUserId;
+        }
+
+        int? quantityChange = null;
+        if (oldQuantity.HasValue && newQuantity.HasValue)
+        {
+            quantityChange = newQuantity.Value - oldQuantity.Value;
+        }
+        else if (newQuantity.HasValue)
+        {
+            quantityChange = newQuantity.Value;
+        }
+        else if (oldQuantity.HasValue)
+        {
+            quantityChange = -oldQuantity.Value;
+        }
+
+        var entry = new ItemsHistory
+        {
+            id_item = itemId,
+            id_box = boxId,
+            id_user = userId,
+            type = type,
+            quantity_change = quantityChange,
+            old_quantity = oldQuantity,
+            new_quantity = newQuantity,
+            notes = notes
+        };
+        _context.ItemsHistory.Add(entry);
+        await _context.SaveChangesAsync();
+    }
+}

--- a/electrostoreAPI/Services/ItemService/ItemService.cs
+++ b/electrostoreAPI/Services/ItemService/ItemService.cs
@@ -1,8 +1,10 @@
 using AutoMapper;
 using ElectrostoreAPI.Dto;
+using ElectrostoreAPI.Enums;
 using ElectrostoreAPI.Extensions;
 using ElectrostoreAPI.Models;
 using ElectrostoreAPI.Services.FileService;
+using ElectrostoreAPI.Services.ItemHistoryService;
 using Microsoft.EntityFrameworkCore;
 using System.Linq.Expressions;
 
@@ -13,15 +15,17 @@ public class ItemService : IItemService
     private readonly IMapper _mapper;
     private readonly ApplicationDbContext _context;
     private readonly IFileService _fileService;
+    private readonly IItemHistoryService _itemHistoryService;
     private readonly string _itemDocumentsPath = "itemDocuments";
     private readonly string _imagesPath = "images";
     private readonly string _imagesThumbnailsPath = "imagesThumbnails";
 
-    public ItemService(IMapper mapper, ApplicationDbContext context, IFileService fileService)
+    public ItemService(IMapper mapper, ApplicationDbContext context, IFileService fileService, IItemHistoryService itemHistoryService)
     {
         _mapper = mapper;
         _context = context;
         _fileService = fileService;
+        _itemHistoryService = itemHistoryService;
     }
 
     public async Task<PaginatedResponseDto<ReadExtendedItemDto>> GetItems(int limit = 100, int offset = 0,
@@ -73,6 +77,7 @@ public class ItemService : IItemService
                 CommandsItems = expand != null && expand.Contains("command_items") ? i.CommandsItems.Take(20).ToList() : null,
                 ProjetsItems = expand != null && expand.Contains("projet_items") ? i.ProjetsItems.Take(20).ToList() : null,
                 ItemsDocuments = expand != null && expand.Contains("item_documents") ? i.ItemsDocuments.Take(20).ToList() : null,
+                ItemsHistory = expand != null && expand.Contains("item_history") ? i.ItemsHistory.OrderByDescending(h => h.created_at).Take(20).ToList() : null,
                 quantity_item = i.ItemsBoxs.Sum(ib => ib.qte_item_box)
             })
             .ToListAsync();
@@ -91,6 +96,7 @@ public class ItemService : IItemService
                     command_items = _mapper.Map<IEnumerable<ReadCommandItemDto>>(i.CommandsItems),
                     projet_items = _mapper.Map<IEnumerable<ReadProjetItemDto>>(i.ProjetsItems),
                     item_documents = _mapper.Map<IEnumerable<ReadItemDocumentDto>>(i.ItemsDocuments),
+                    item_history = _mapper.Map<IEnumerable<ReadItemHistoryDto>>(i.ItemsHistory),
                     quantity_item = i.quantity_item
                 };
             }).ToList(),
@@ -125,6 +131,7 @@ public class ItemService : IItemService
                 CommandsItems = expand != null && expand.Contains("command_items") ? i.CommandsItems.Take(20).ToList() : null,
                 ProjetsItems = expand != null && expand.Contains("projet_items") ? i.ProjetsItems.Take(20).ToList() : null,
                 ItemsDocuments = expand != null && expand.Contains("item_documents") ? i.ItemsDocuments.Take(20).ToList() : null,
+                ItemsHistory = expand != null && expand.Contains("item_history") ? i.ItemsHistory.OrderByDescending(h => h.created_at).Take(20).ToList() : null,
                 quantity_item = i.ItemsBoxs.Sum(ib => ib.qte_item_box)
             })
             .FirstOrDefaultAsync() ?? throw new KeyNotFoundException($"Item with id '{id}' not found");
@@ -140,6 +147,7 @@ public class ItemService : IItemService
             command_items = _mapper.Map<IEnumerable<ReadCommandItemDto>>(item.CommandsItems),
             projet_items = _mapper.Map<IEnumerable<ReadProjetItemDto>>(item.ProjetsItems),
             item_documents = _mapper.Map<IEnumerable<ReadItemDocumentDto>>(item.ItemsDocuments),
+            item_history = _mapper.Map<IEnumerable<ReadItemHistoryDto>>(item.ItemsHistory),
             quantity_item = item.quantity_item
         };
     }
@@ -162,6 +170,7 @@ public class ItemService : IItemService
         await _fileService.CreateDirectory(Path.Combine(_imagesThumbnailsPath, item.id_item.ToString()));
         await _fileService.CreateDirectory(Path.Combine(_itemDocumentsPath, item.id_item.ToString()));
         await _context.SaveChangesAsync();
+        await _itemHistoryService.LogHistory(item.id_item, null, ItemHistoryType.ItemCreated);
         return _mapper.Map<ReadItemDto>(item);
     }
 
@@ -200,12 +209,14 @@ public class ItemService : IItemService
             itemToUpdate.id_img = itemDto.id_img;
         }
         await _context.SaveChangesAsync();
+        await _itemHistoryService.LogHistory(id, null, ItemHistoryType.ItemUpdated);
         return _mapper.Map<ReadItemDto>(itemToUpdate);
     }
 
     public async Task DeleteItem(int id)
     {
         var itemToDelete = await _context.Items.FindAsync(id) ?? throw new KeyNotFoundException($"Item with id '{id}' not found");
+        await _itemHistoryService.LogHistory(id, null, ItemHistoryType.ItemDeleted);
         _context.Items.Remove(itemToDelete);
         await _fileService.DeleteDirectory(Path.Combine(_imagesPath, id.ToString()));
         await _fileService.DeleteDirectory(Path.Combine(_imagesThumbnailsPath, id.ToString()));

--- a/openapi/swagger.json
+++ b/openapi/swagger.json
@@ -656,6 +656,247 @@
         }
       }
     },
+    "/api/carrier": {
+      "get": {
+        "tags": [
+          "Carrier"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "idResearch",
+            "in": "query",
+            "description": "(Optional) Fields to select list of ID to research in the base. Multiple values can be specified by separating them with ','.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "(Optional) RSQL string to filter results. Example: 'nom_carrier=like=example'.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "(Optional) Sort string to order results. Example: 'nom_carrier,asc' or 'nom_carrier,desc'.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadCarrierDtoPaginatedResponseDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadCarrierDtoPaginatedResponseDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadCarrierDtoPaginatedResponseDto"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Carrier"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCarrierDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCarrierDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCarrierDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadCarrierDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadCarrierDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadCarrierDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/carrier/{id_carrier}": {
+      "get": {
+        "tags": [
+          "Carrier"
+        ],
+        "parameters": [
+          {
+            "name": "id_carrier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadCarrierDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadCarrierDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadCarrierDto"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Carrier"
+        ],
+        "parameters": [
+          {
+            "name": "id_carrier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCarrierDto"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCarrierDto"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateCarrierDto"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadCarrierDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadCarrierDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadCarrierDto"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Carrier"
+        ],
+        "parameters": [
+          {
+            "name": "id_carrier",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/api/command": {
       "get": {
         "tags": [
@@ -683,7 +924,7 @@
           {
             "name": "expand",
             "in": "query",
-            "description": "(Optional) Fields to expand. Possible values: 'commands_commentaires', 'commands_documents', 'commands_items'. Multiple values can be specified by separating them with ','.",
+            "description": "(Optional) Fields to expand. Possible values: 'commands_commentaires', 'commands_documents', 'commands_history', 'commands_items'. Multiple values can be specified by separating them with ','.",
             "schema": {
               "type": "array",
               "items": {
@@ -808,7 +1049,7 @@
           {
             "name": "expand",
             "in": "query",
-            "description": "(Optional) Fields to expand. Possible values: 'commands_commentaires', 'commands_documents', 'commands_items'. Multiple values can be specified by separating them with ','.",
+            "description": "(Optional) Fields to expand. Possible values: 'commands_commentaires', 'commands_documents', 'commands_history', 'commands_items'. Multiple values can be specified by separating them with ','.",
             "schema": {
               "type": "array",
               "items": {
@@ -1573,7 +1814,7 @@
           {
             "name": "filter",
             "in": "query",
-            "description": "(Optional) RSQL filter. Example: 'status_projet==0'.",
+            "description": "(Optional) RSQL string to filter results. Example: 'prix_command_item=gt=100'.",
             "schema": {
               "type": "string"
             }
@@ -1581,7 +1822,7 @@
           {
             "name": "sort",
             "in": "query",
-            "description": "(Optional) Sort string. Example: 'created_at,asc' or 'created_at,desc'.",
+            "description": "(Optional) Sort string to order results. Example: 'prix_command_item,asc' or 'prix_command_item,desc'.",
             "schema": {
               "type": "string"
             }
@@ -1611,7 +1852,7 @@
         }
       }
     },
-    "/api/command/{id_command}/history/{id_command_history}": {
+    "/api/command/{id_command}/history/{id_history}": {
       "get": {
         "tags": [
           "CommandHistory"
@@ -1627,7 +1868,7 @@
             }
           },
           {
-            "name": "id_command_history",
+            "name": "id_history",
             "in": "path",
             "required": true,
             "schema": {
@@ -3918,6 +4159,194 @@
         "responses": {
           "200": {
             "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/item/{id_item}/history": {
+      "get": {
+        "tags": [
+          "ItemHistory"
+        ],
+        "parameters": [
+          {
+            "name": "id_item",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "(Optional) RSQL string to filter results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "(Optional) Sort string. Example: 'created_at,desc'.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadExtendedItemHistoryDtoPaginatedResponseDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadExtendedItemHistoryDtoPaginatedResponseDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadExtendedItemHistoryDtoPaginatedResponseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/item/{id_item}/history/{id_history}": {
+      "get": {
+        "tags": [
+          "ItemHistory"
+        ],
+        "parameters": [
+          {
+            "name": "id_item",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "id_history",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadExtendedItemHistoryDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadExtendedItemHistoryDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadExtendedItemHistoryDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/item/history": {
+      "get": {
+        "tags": [
+          "ItemHistory"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "(Optional) RSQL string to filter results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "(Optional) Sort string. Example: 'created_at,desc'.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadExtendedItemHistoryDtoPaginatedResponseDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadExtendedItemHistoryDtoPaginatedResponseDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReadExtendedItemHistoryDtoPaginatedResponseDto"
+                }
+              }
+            }
           }
         }
       }
@@ -12468,6 +12897,52 @@
         }
       }
     },
+    "/api/user/{id_user}/push-subscriptions/testPush": {
+      "post": {
+        "tags": [
+          "UserPushSubscription"
+        ],
+        "parameters": [
+          {
+            "name": "id_user",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/user/{id_user}/push-subscriptions/testEmail": {
+      "post": {
+        "tags": [
+          "UserPushSubscription"
+        ],
+        "parameters": [
+          {
+            "name": "id_user",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
     "/api/user/{id_user}/sessions": {
       "get": {
         "tags": [
@@ -12654,6 +13129,37 @@
           }
         }
       }
+    },
+    "/api/webhook/17track": {
+      "post": {
+        "tags": [
+          "WebHook"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "type": "string"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -12744,6 +13250,21 @@
           }
         },
         "additionalProperties": false
+      },
+      "CommandStatus": {
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8
+        ],
+        "type": "integer",
+        "format": "int32"
       },
       "CreateBoxByStoreDto": {
         "required": [
@@ -12837,6 +13358,41 @@
         },
         "additionalProperties": false
       },
+      "CreateCarrierDto": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "country": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "country_iso": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "tel": {
+            "type": "string",
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "CreateCommandCommentaireByCommandDto": {
         "required": [
           "contenu_command_commentaire"
@@ -12854,8 +13410,10 @@
       "CreateCommandDto": {
         "required": [
           "date_command",
+          "id_carrier",
           "prix_command",
           "status_command",
+          "tracking_number",
           "url_command"
         ],
         "type": "object",
@@ -12872,9 +13430,7 @@
             "format": "uri"
           },
           "status_command": {
-            "maxLength": 50,
-            "minLength": 1,
-            "type": "string"
+            "$ref": "#/components/schemas/CommandStatus"
           },
           "date_command": {
             "type": "string",
@@ -12883,6 +13439,20 @@
           "date_livraison_command": {
             "type": "string",
             "format": "date-time",
+            "nullable": true
+          },
+          "tracking_number": {
+            "maxLength": 100,
+            "type": "string",
+            "nullable": true
+          },
+          "id_carrier": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "is_tracking_requested": {
+            "type": "boolean",
             "nullable": true
           }
         },
@@ -12959,9 +13529,7 @@
             "type": "string"
           },
           "action_cronjob": {
-            "maxLength": 50,
-            "minLength": 1,
-            "type": "string"
+            "$ref": "#/components/schemas/CronJobAction"
           },
           "params_cronjob": {
             "type": "string",
@@ -13446,6 +14014,19 @@
         },
         "additionalProperties": false
       },
+      "CronJobAction": {
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
       "ErrorDetail": {
         "required": [
           "data",
@@ -13536,6 +14117,18 @@
           }
         },
         "additionalProperties": false
+      },
+      "ItemHistoryType": {
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "type": "integer",
+        "format": "int32"
       },
       "LoginRequest": {
         "required": [
@@ -13939,6 +14532,11 @@
             "type": "string",
             "nullable": true
           },
+          "last_seen_camera": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
           "created_at": {
             "type": "string",
             "format": "date-time"
@@ -13963,6 +14561,89 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ReadCameraDto"
+            },
+            "nullable": true
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationDto"
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterDto"
+            },
+            "nullable": true
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SorterDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ReadCarrierDto": {
+        "type": "object",
+        "properties": {
+          "id_carrier": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "key": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "country": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "country_iso": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "tel": {
+            "type": "string",
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ReadCarrierDtoPaginatedResponseDto": {
+        "required": [
+          "data",
+          "filters",
+          "pagination",
+          "sort"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadCarrierDto"
             },
             "nullable": true
           },
@@ -14101,7 +14782,7 @@
       },
       "ReadCommandDto": {
         "required": [
-          "status_command",
+          "tracking_number",
           "url_command"
         ],
         "type": "object",
@@ -14119,8 +14800,7 @@
             "nullable": true
           },
           "status_command": {
-            "type": "string",
-            "nullable": true
+            "$ref": "#/components/schemas/CommandStatus"
           },
           "date_command": {
             "type": "string",
@@ -14129,6 +14809,42 @@
           "date_livraison_command": {
             "type": "string",
             "format": "date-time",
+            "nullable": true
+          },
+          "tracking_number": {
+            "type": "string",
+            "nullable": true
+          },
+          "id_carrier": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "carrier_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "is_tracking_requested": {
+            "type": "boolean"
+          },
+          "is_tracking_validated": {
+            "type": "boolean"
+          },
+          "is_active": {
+            "type": "boolean"
+          },
+          "shipper_adress": {
+            "type": "string",
+            "nullable": true
+          },
+          "recipient_adress": {
+            "type": "string",
+            "nullable": true
+          },
+          "last_status": {
+            "$ref": "#/components/schemas/TrackingStatus"
+          },
+          "raw_data": {
+            "type": "string",
             "nullable": true
           },
           "created_at": {
@@ -14143,9 +14859,6 @@
         "additionalProperties": false
       },
       "ReadCommandHistoryDto": {
-        "required": [
-          "status_command_history"
-        ],
         "type": "object",
         "properties": {
           "id_command_history": {
@@ -14156,25 +14869,57 @@
             "type": "integer",
             "format": "int32"
           },
-          "status_command_history": {
+          "status": {
+            "$ref": "#/components/schemas/TrackingStatus"
+          },
+          "sub_status": {
             "type": "string",
             "nullable": true
           },
-          "tracking_number": {
+          "description": {
             "type": "string",
             "nullable": true
           },
-          "carrier": {
+          "location": {
             "type": "string",
             "nullable": true
           },
-          "tracking_event": {
+          "stage": {
             "type": "string",
             "nullable": true
           },
-          "event_at": {
+          "event_time_utc": {
             "type": "string",
-            "format": "date-time"
+            "format": "date-time",
+            "nullable": true
+          },
+          "timezone": {
+            "type": "string",
+            "nullable": true
+          },
+          "country": {
+            "type": "string",
+            "nullable": true
+          },
+          "state": {
+            "type": "string",
+            "nullable": true
+          },
+          "city": {
+            "type": "string",
+            "nullable": true
+          },
+          "postal_code": {
+            "type": "string",
+            "nullable": true
+          },
+          "latitude": {
+            "type": "string",
+            "nullable": true
+          },
+          "longitude": {
+            "type": "string",
+            "nullable": true
           },
           "created_at": {
             "type": "string",
@@ -14259,6 +15004,10 @@
           "demo_mode": {
             "type": "boolean"
           },
+          "app_language": {
+            "type": "string",
+            "nullable": true
+          },
           "max_length_url": {
             "type": "integer",
             "format": "int32"
@@ -14283,6 +15032,14 @@
             "type": "integer",
             "format": "int32"
           },
+          "max_length_location": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "max_length_cron_expression": {
+            "type": "integer",
+            "format": "int32"
+          },
           "max_length_ip": {
             "type": "integer",
             "format": "int32"
@@ -14295,7 +15052,43 @@
             "type": "integer",
             "format": "int32"
           },
+          "max_length_device_name": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "max_length_push_key": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "max_length_push_auth": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "max_length_tracking_number": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "max_length_carrier_name": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "max_length_timezone": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "max_length_coordinate": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "max_length_postal_code": {
+            "type": "integer",
+            "format": "int32"
+          },
           "max_size_document_in_mb": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "max_size_image_in_mb": {
             "type": "integer",
             "format": "int32"
           },
@@ -14339,7 +15132,6 @@
       },
       "ReadCronJobDto": {
         "required": [
-          "action_cronjob",
           "cron_expression",
           "name_cronjob"
         ],
@@ -14358,8 +15150,7 @@
             "nullable": true
           },
           "action_cronjob": {
-            "type": "string",
-            "nullable": true
+            "$ref": "#/components/schemas/CronJobAction"
           },
           "params_cronjob": {
             "type": "string",
@@ -14666,7 +15457,7 @@
       },
       "ReadExtendedCommandDto": {
         "required": [
-          "status_command",
+          "tracking_number",
           "url_command"
         ],
         "type": "object",
@@ -14684,8 +15475,7 @@
             "nullable": true
           },
           "status_command": {
-            "type": "string",
-            "nullable": true
+            "$ref": "#/components/schemas/CommandStatus"
           },
           "date_command": {
             "type": "string",
@@ -14694,6 +15484,42 @@
           "date_livraison_command": {
             "type": "string",
             "format": "date-time",
+            "nullable": true
+          },
+          "tracking_number": {
+            "type": "string",
+            "nullable": true
+          },
+          "id_carrier": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "carrier_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "is_tracking_requested": {
+            "type": "boolean"
+          },
+          "is_tracking_validated": {
+            "type": "boolean"
+          },
+          "is_active": {
+            "type": "boolean"
+          },
+          "shipper_adress": {
+            "type": "string",
+            "nullable": true
+          },
+          "recipient_adress": {
+            "type": "string",
+            "nullable": true
+          },
+          "last_status": {
+            "$ref": "#/components/schemas/TrackingStatus"
+          },
+          "raw_data": {
+            "type": "string",
             "nullable": true
           },
           "created_at": {
@@ -14713,6 +15539,10 @@
             "format": "int32"
           },
           "commands_items_count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "commands_history_count": {
             "type": "integer",
             "format": "int32"
           },
@@ -14736,6 +15566,16 @@
               "$ref": "#/components/schemas/ReadCommandItemDto"
             },
             "nullable": true
+          },
+          "commands_history": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadCommandHistoryDto"
+            },
+            "nullable": true
+          },
+          "carrier": {
+            "$ref": "#/components/schemas/ReadCarrierDto"
           }
         },
         "additionalProperties": false
@@ -15036,6 +15876,106 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/ReadExtendedItemDto"
+            },
+            "nullable": true
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationDto"
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterDto"
+            },
+            "nullable": true
+          },
+          "sort": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SorterDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ReadExtendedItemHistoryDto": {
+        "type": "object",
+        "properties": {
+          "id_item_history": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id_item": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "id_box": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "id_user": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/ItemHistoryType"
+          },
+          "quantity_change": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "old_quantity": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "new_quantity": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "item": {
+            "$ref": "#/components/schemas/ReadItemDto"
+          },
+          "box": {
+            "$ref": "#/components/schemas/ReadBoxDto"
+          },
+          "user": {
+            "$ref": "#/components/schemas/ReadUserDto"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ReadExtendedItemHistoryDtoPaginatedResponseDto": {
+        "required": [
+          "data",
+          "filters",
+          "pagination",
+          "sort"
+        ],
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReadExtendedItemHistoryDto"
             },
             "nullable": true
           },
@@ -15641,6 +16581,9 @@
             "type": "string",
             "format": "date-time",
             "nullable": true
+          },
+          "is_mqtt_connected_store": {
+            "type": "boolean"
           },
           "created_at": {
             "type": "string",
@@ -16665,16 +17608,27 @@
           "mqtt_connected": {
             "type": "boolean"
           },
+          "kafka_connected": {
+            "type": "boolean"
+          },
           "ia_status": {
             "type": "string",
             "nullable": true
           },
           "ia_training_in_progress": {
-            "type": "boolean",
-            "nullable": true
+            "type": "integer",
+            "format": "int32"
           },
           "notif_status": {
             "type": "string",
+            "nullable": true
+          },
+          "notif_smtp": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "notif_webPush": {
+            "type": "boolean",
             "nullable": true
           },
           "cron_status": {
@@ -16683,6 +17637,13 @@
           },
           "worker_status": {
             "type": "string",
+            "nullable": true
+          },
+          "external_services": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
             "nullable": true
           }
         },
@@ -16737,6 +17698,9 @@
             "type": "string",
             "format": "date-time",
             "nullable": true
+          },
+          "is_mqtt_connected_store": {
+            "type": "boolean"
           },
           "created_at": {
             "type": "string",
@@ -17108,6 +18072,22 @@
         },
         "additionalProperties": false
       },
+      "TrackingStatus": {
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
       "UpdateAccessTokenDto": {
         "type": "object",
         "properties": {
@@ -17267,6 +18247,37 @@
         },
         "additionalProperties": false
       },
+      "UpdateCarrierDto": {
+        "type": "object",
+        "properties": {
+          "country": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "country_iso": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "tel": {
+            "type": "string",
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
       "UpdateCommandCommentaireDto": {
         "type": "object",
         "properties": {
@@ -17305,9 +18316,7 @@
             "nullable": true
           },
           "status_command": {
-            "maxLength": 50,
-            "type": "string",
-            "nullable": true
+            "$ref": "#/components/schemas/CommandStatus"
           },
           "date_command": {
             "type": "string",
@@ -17317,6 +18326,20 @@
           "date_livraison_command": {
             "type": "string",
             "format": "date-time",
+            "nullable": true
+          },
+          "tracking_number": {
+            "maxLength": 100,
+            "type": "string",
+            "nullable": true
+          },
+          "id_carrier": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "is_tracking_requested": {
+            "type": "boolean",
             "nullable": true
           }
         },
@@ -17355,9 +18378,7 @@
             "nullable": true
           },
           "action_cronjob": {
-            "maxLength": 50,
-            "type": "string",
-            "nullable": true
+            "$ref": "#/components/schemas/CronJobAction"
           },
           "params_cronjob": {
             "type": "string",


### PR DESCRIPTION
add "Item History" feature to the API, enabling tracking and querying of changes to items, such as stock updates and actions performed by users. It includes database schema changes, new models and DTOs, controller endpoints, and integration with the item/box services to log history automatically.