### PR TITLE
feat: Add test notification

### DIFF
--- a/electrostoreAPI/Controllers/UserPushSubscriptionController.cs
+++ b/electrostoreAPI/Controllers/UserPushSubscriptionController.cs
@@ -65,5 +65,21 @@ namespace ElectrostoreAPI.Controllers
             await _userPushSubscriptionService.DeletePushSubscription(id_subscription, id_user);
             return NoContent();
         }
+
+        [HttpPost("testPush")]
+        [Authorize(Policy = "AccessToken")]
+        public async Task<ActionResult> SendTestPushNotification([FromRoute] int id_user)
+        {
+            await _userPushSubscriptionService.SendTestPushNotification(id_user);
+            return NoContent();
+        }
+
+        [HttpPost("testEmail")]
+        [Authorize(Policy = "AccessToken")]
+        public async Task<ActionResult> SendTestEmailNotification([FromRoute] int id_user)
+        {
+            await _userPushSubscriptionService.SendTestEmailNotification(id_user);
+            return NoContent();
+        }
     }
 }

--- a/electrostoreAPI/Controllers/WebHookController.cs
+++ b/electrostoreAPI/Controllers/WebHookController.cs
@@ -1,0 +1,35 @@
+using ElectrostoreAPI.Services.WebHookService;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ElectrostoreAPI.Controllers
+{
+    [ApiController]
+    [Route("api/webhook/17track")]
+
+    public class WebHookController : ControllerBase
+    {
+        private readonly IWebHookService _webHookService;
+
+        public WebHookController(IWebHookService webHookService)
+        {
+            _webHookService = webHookService;
+        }
+
+        [HttpPost]
+        [AllowAnonymous]
+        public async Task Post17Track([FromBody] string body)
+        {
+            Console.WriteLine("Received webhook headers:");
+            Console.WriteLine(Request.Headers.ToString());
+            Console.WriteLine("Received webhook from 17Track:");
+            Console.WriteLine(body);
+            var result = await _webHookService.Process17TrackWebhook(body);
+            if (!result)
+            {
+                throw new Exception("Failed to process webhook");
+            }
+            Ok();
+        }
+    }
+}

--- a/electrostoreAPI/Services/UserPushSubscriptionService/IUserPushSubscriptionService.cs
+++ b/electrostoreAPI/Services/UserPushSubscriptionService/IUserPushSubscriptionService.cs
@@ -13,4 +13,8 @@ public interface IUserPushSubscriptionService
     Task DeletePushSubscription(int id, int? userId = null);
 
     Task<List<ReadUserPushSubscriptionDto>> GetPushSubscriptionsByUserIdAsync(int userId, CancellationToken cancellationToken = default);
+
+    Task SendTestPushNotification(int userId);
+
+    Task SendTestEmailNotification(int userId);
 }

--- a/electrostoreAPI/Services/UserPushSubscriptionService/UserPushSubscriptionService.cs
+++ b/electrostoreAPI/Services/UserPushSubscriptionService/UserPushSubscriptionService.cs
@@ -1,9 +1,12 @@
 using AutoMapper;
 using ElectrostoreAPI.Dto;
 using ElectrostoreAPI.Extensions;
+using ElectrostoreAPI.Kafka.Messages;
+using ElectrostoreAPI.Kafka.Producer;
 using ElectrostoreAPI.Models;
 using Microsoft.EntityFrameworkCore;
 using System.Linq.Expressions;
+using System.Text.Json;
 
 
 namespace ElectrostoreAPI.Services.UserPushSubscriptionService;
@@ -12,11 +15,15 @@ public class UserPushSubscriptionService : IUserPushSubscriptionService
 {
     private readonly ApplicationDbContext _context;
     private readonly IMapper _mapper;
+    private readonly IConfiguration _configuration;
+    private readonly IKafkaProducerService _kafkaProducerService;
 
-    public UserPushSubscriptionService(ApplicationDbContext context, IMapper mapper)
+    public UserPushSubscriptionService(ApplicationDbContext context, IMapper mapper, IConfiguration configuration, IKafkaProducerService kafkaProducerService)
     {
         _context = context;
         _mapper = mapper;
+        _configuration = configuration;
+        _kafkaProducerService = kafkaProducerService;
     }
 
     public async Task<PaginatedResponseDto<ReadUserPushSubscriptionDto>> GetPushSubscriptionsByUserId(int userId, int limit = 100, int offset = 0,
@@ -133,5 +140,47 @@ public class UserPushSubscriptionService : IUserPushSubscriptionService
             .Where(s => s.id_user == userId)
             .ToListAsync(cancellationToken);
         return _mapper.Map<List<ReadUserPushSubscriptionDto>>(subscriptions);
+    }
+
+    public async Task SendTestPushNotification(int userId)
+    {
+        if (!await _context.Users.AnyAsync(u => u.id_user == userId))
+        {
+            throw new KeyNotFoundException($"User with id {userId} not found");
+        }
+        var notification = new NotificationMessage
+        {
+            Types = ["webPush"],
+            RecipientUserId = userId,
+            Title = "Test notification",
+            Body = "This is a test push notification",
+            Language = _configuration.GetValue<string>("AppLanguage") ?? "fr"
+        };
+        await _kafkaProducerService.PublishAsync(
+            "notification-requests",
+            $"user-{userId}-push-test",
+            JsonSerializer.Serialize(notification)
+        );
+    }
+
+    public async Task SendTestEmailNotification(int userId)
+    {
+        if (!await _context.Users.AnyAsync(u => u.id_user == userId))
+        {
+            throw new KeyNotFoundException($"User with id {userId} not found");
+        }
+        var notification = new NotificationMessage
+        {
+            Types = ["email"],
+            RecipientUserId = userId,
+            Title = "Test notification",
+            Body = "This is a test email notification",
+            Language = _configuration.GetValue<string>("AppLanguage") ?? "fr"
+        };
+        await _kafkaProducerService.PublishAsync(
+            "notification-requests",
+            $"user-{userId}-email-test",
+            JsonSerializer.Serialize(notification)
+        );
     }
 }

--- a/electrostoreAPI/Services/WebHookService/IWebHookService.cs
+++ b/electrostoreAPI/Services/WebHookService/IWebHookService.cs
@@ -1,0 +1,8 @@
+using ElectrostoreAPI.Dto;
+
+namespace ElectrostoreAPI.Services.WebHookService;
+
+public interface IWebHookService
+{
+    public Task<bool> Process17TrackWebhook(string body);
+}

--- a/electrostoreAPI/Services/WebHookService/WebHookService.cs
+++ b/electrostoreAPI/Services/WebHookService/WebHookService.cs
@@ -1,0 +1,68 @@
+using AutoMapper;
+using ElectrostoreAPI.Dto;
+using ElectrostoreAPI.Models;
+using ElectrostoreAPI.Services.CommandService;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+
+namespace ElectrostoreAPI.Services.WebHookService;
+
+public class WebHookService : IWebHookService
+{
+    private readonly IMapper _mapper;
+    private readonly ApplicationDbContext _context;
+    private readonly IConfiguration _configuration;
+    private readonly ICommandService _commandService;
+    public WebHookService(IMapper mapper, ApplicationDbContext context, IConfiguration configuration, ICommandService commandService)
+    {
+        _mapper = mapper;
+        _context = context;
+        _configuration = configuration;
+        _commandService = commandService;
+    }
+
+    public Task<bool> Process17TrackWebhook(string body)
+    {
+        if (_configuration.GetValue<bool>("17Track:Enable") == false)
+        {
+            Console.WriteLine("17Track webhook processing is disabled.");
+            return Task.FromResult(false);
+        }
+        var apiKey = _configuration.GetValue<string>("17Track:ApiKey");
+        if (string.IsNullOrEmpty(apiKey))
+        {
+            Console.WriteLine("API key is not configured.");
+            return Task.FromResult(false);
+        }
+        var signature = getGeneratedSignature(body, apiKey);
+        Console.WriteLine($"Generated Signature: {signature}");
+        /* if (!Request.Headers.TryGetValue("X-17Track-Signature", out var receivedSignature) || receivedSignature != signature)
+        {
+            Console.WriteLine("Invalid signature.");
+            return Task.FromResult(false);
+        } */
+
+        // Implement the logic to process the webhook data here
+
+
+        return Task.FromResult(true);
+    }
+
+    private string getGeneratedSignature(string requestText, string key)
+    {
+        var src = requestText + "/" + key;
+
+        using var sha256 = System.Security.Cryptography.SHA256.Create();
+        byte[] hash = sha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(src));
+
+        var hexString = new System.Text.StringBuilder(hash.Length * 2);
+        foreach (var b in hash)
+        {
+            hexString.Append(b.ToString("x2"));
+        }
+        return hexString.ToString();
+    }
+}


### PR DESCRIPTION
Adds two authenticated user push subscription endpoints to trigger test web push and email notifications, wired through `UserPushSubscriptionService` and Kafka `notification-requests` messages. Introduces a new 17Track webhook controller and service with config-based enablement/API key checks plus signature generation scaffolding for webhook validation.