### PR TITLE
chore: Bump Vite, Vitest, and js-yaml dependencies

### DIFF
--- a/.github/workflows/PRtestsAPI.yml
+++ b/.github/workflows/PRtestsAPI.yml
@@ -16,9 +16,9 @@ jobs:
         working-directory: ./electrostoreAPI
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Set up C#
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '9.0.x'
     - name: Install dependencies

--- a/.github/workflows/PRtestsCRON.yml
+++ b/.github/workflows/PRtestsCRON.yml
@@ -16,9 +16,9 @@ jobs:
         working-directory: ./electrostoreCRON
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Set up C#
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '9.0.x'
     - name: Install dependencies

--- a/.github/workflows/PRtestsFRONT.yml
+++ b/.github/workflows/PRtestsFRONT.yml
@@ -16,7 +16,7 @@ jobs:
         working-directory: ./electrostoreFRONT
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
@@ -50,7 +50,7 @@ jobs:
     - name: Run SonarQube scan
       id: sonarqube
       continue-on-error: true
-      uses: SonarSource/sonarqube-scan-action@v6
+      uses: SonarSource/sonarqube-scan-action@v8
       env:
         SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/PRtestsIA.yml
+++ b/.github/workflows/PRtestsIA.yml
@@ -16,9 +16,9 @@ jobs:
         working-directory: ./electrostoreIA
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Set up C#
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '9.0.x'
     - name: Install dependencies

--- a/.github/workflows/PRtestsNOTIF.yml
+++ b/.github/workflows/PRtestsNOTIF.yml
@@ -16,9 +16,9 @@ jobs:
         working-directory: ./electrostoreNOTIF
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Set up C#
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '9.0.x'
     - name: Install dependencies

--- a/.github/workflows/PRtestsWORKER.yml
+++ b/.github/workflows/PRtestsWORKER.yml
@@ -16,9 +16,9 @@ jobs:
         working-directory: ./electrostoreWORKER
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Set up C#
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '9.0.x'
     - name: Install dependencies

--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -25,7 +25,7 @@ jobs:
         DEPLOY: ${{ env.DEPLOY }}
         RELEASE: ${{ env.RELEASE }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       matrix: ${{ steps.targets.outputs.matrix }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.branch }}
       - name: Create matrix
@@ -84,15 +84,15 @@ jobs:
       packages: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         ref: ${{ inputs.branch }}
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
     - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
@@ -113,7 +113,7 @@ jobs:
         VERSION: ${{ inputs.version }}-arm64
         REPO: ${{ steps.repo.outputs.lowercase }}
         BUILDX_NO_DEFAULT_ATTESTATIONS: 1
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 30
         retry_wait_seconds: 30
@@ -147,15 +147,15 @@ jobs:
       packages: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         ref: ${{ inputs.branch }}
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
     - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}
@@ -176,7 +176,7 @@ jobs:
         VERSION: ${{ inputs.version }}-amd64
         REPO: ${{ steps.repo.outputs.lowercase }}
         BUILDX_NO_DEFAULT_ATTESTATIONS: 1
-      uses: nick-fields/retry@v3
+      uses: nick-fields/retry@v4
       with:
         timeout_minutes: 30
         retry_wait_seconds: 30
@@ -211,15 +211,15 @@ jobs:
       packages: write
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         ref: ${{ inputs.branch }}
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
     - name: Log in to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.repository_owner }}

--- a/.github/workflows/deployDemo.yml
+++ b/.github/workflows/deployDemo.yml
@@ -20,7 +20,7 @@ jobs:
         DEPLOY: ${{ env.DEPLOY }}
         RELEASE: ${{ env.RELEASE }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -75,7 +75,7 @@ jobs:
     if: needs.init-work.outputs.DEPLOY == 'true'
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
     - name: Helper to convert github repo to lowercase
       id: repo
       uses: ASzc/change-string-case-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ inputs.branch }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Generate Changelog
         if: ${{ steps.branch_tags.outputs.branch_tags != 'none' }}
-        uses: metcalfc/changelog-generator@v4.6.2
+        uses: metcalfc/changelog-generator@v4.7.0
         id: changelog
         with:
           mytoken: ${{ secrets.GITHUB_TOKEN }}
@@ -71,7 +71,7 @@ jobs:
       
       - name: Create First Release
         if: ${{ steps.branch_tags.outputs.branch_tags == 'none' }}
-        uses: ncipollo/release-action@v1.12.0
+        uses: ncipollo/release-action@v1.21.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -86,7 +86,7 @@ jobs:
       - name: Create Release
         id: create_release
         if: ${{ steps.changelog.outputs.changelog != '' }}
-        uses: ncipollo/release-action@v1.12.0
+        uses: ncipollo/release-action@v1.21.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,11 +43,11 @@ jobs:
         working-directory: ./${{ matrix.source_dir }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         ref: ${{ inputs.branch }}
     - name: Set up C#
-      uses: actions/setup-dotnet@v4
+      uses: actions/setup-dotnet@v5
       with:
         dotnet-version: '9.0.x'
     - name: Install dependencies
@@ -92,11 +92,11 @@ jobs:
         working-directory: ./electrostoreFRONT
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         ref: ${{ inputs.branch }}
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '24'
     - name: Install dependencies
@@ -108,14 +108,14 @@ jobs:
     - name: Cypress run
       env:
         VITE_API_URL: http://localhost/vite_api_url_placeholder/api
-      uses: cypress-io/github-action@v6
+      uses: cypress-io/github-action@v7
       with:
         start: npm run dev
         wait-on: 'http://localhost:5173'
         wait-on-timeout: 30
         working-directory: ./tests/electrostoreFRONT
     - name: Upload screenshots
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       if: failure()
       with:
         name: cypress-screenshots
@@ -123,7 +123,7 @@ jobs:
     - name: SonarScanner
       id: sonarqube
       continue-on-error: true
-      uses: SonarSource/sonarqube-scan-action@v6
+      uses: SonarSource/sonarqube-scan-action@v8
       env:
         SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/update-swagger.yml
+++ b/.github/workflows/update-swagger.yml
@@ -6,7 +6,7 @@ jobs:
   updateSwagger:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Get Latest Swagger UI Release
         id: swagger-ui
         run: |
@@ -39,7 +39,7 @@ jobs:
           # Update current release
           echo ${{ steps.swagger-ui.outputs.release_tag }} > swagger-ui.version
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: Update swagger-ui to ${{ steps.swagger-ui.outputs.release_tag }}
           title: Update SwaggerUI to ${{ steps.swagger-ui.outputs.release_tag }}

--- a/electrostoreFRONT/package-lock.json
+++ b/electrostoreFRONT/package-lock.json
@@ -5146,10 +5146,20 @@
             "dev": true
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -7116,9 +7126,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.4.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-            "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+            "version": "6.4.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+            "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
             "dev": true,
             "dependencies": {
                 "esbuild": "^0.25.0",

--- a/tests/electrostoreFRONT/package-lock.json
+++ b/tests/electrostoreFRONT/package-lock.json
@@ -1310,12 +1310,13 @@
             ]
         },
         "node_modules/@types/chai": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
-            "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
             "dev": true,
             "dependencies": {
-                "@types/deep-eql": "*"
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
             }
         },
         "node_modules/@types/deep-eql": {
@@ -1382,9 +1383,9 @@
             }
         },
         "node_modules/@vitest/coverage-v8": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
-            "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.6.tgz",
+            "integrity": "sha512-LsAdmUapA0qSN306d8+zOyawM0hFm2m2Hg9IwVNIKBm+qJV8cijiq2c+gxKZcB1HCfIWAy+0qEZDCUQA58A1cw==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.3.0",
@@ -1405,8 +1406,8 @@
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
-                "@vitest/browser": "3.2.4",
-                "vitest": "3.2.4"
+                "@vitest/browser": "3.2.6",
+                "vitest": "3.2.6"
             },
             "peerDependenciesMeta": {
                 "@vitest/browser": {
@@ -1415,14 +1416,14 @@
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-            "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+            "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
             "dev": true,
             "dependencies": {
                 "@types/chai": "^5.2.2",
-                "@vitest/spy": "3.2.4",
-                "@vitest/utils": "3.2.4",
+                "@vitest/spy": "3.2.6",
+                "@vitest/utils": "3.2.6",
                 "chai": "^5.2.0",
                 "tinyrainbow": "^2.0.0"
             },
@@ -1431,12 +1432,12 @@
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-            "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+            "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
             "dev": true,
             "dependencies": {
-                "@vitest/spy": "3.2.4",
+                "@vitest/spy": "3.2.6",
                 "estree-walker": "^3.0.3",
                 "magic-string": "^0.30.17"
             },
@@ -1457,9 +1458,9 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-            "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+            "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
             "dev": true,
             "dependencies": {
                 "tinyrainbow": "^2.0.0"
@@ -1469,12 +1470,12 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-            "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+            "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
             "dev": true,
             "dependencies": {
-                "@vitest/utils": "3.2.4",
+                "@vitest/utils": "3.2.6",
                 "pathe": "^2.0.3",
                 "strip-literal": "^3.0.0"
             },
@@ -1483,12 +1484,12 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-            "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+            "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
             "dev": true,
             "dependencies": {
-                "@vitest/pretty-format": "3.2.4",
+                "@vitest/pretty-format": "3.2.6",
                 "magic-string": "^0.30.17",
                 "pathe": "^2.0.3"
             },
@@ -1497,9 +1498,9 @@
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-            "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+            "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
             "dev": true,
             "dependencies": {
                 "tinyspy": "^4.0.3"
@@ -1509,12 +1510,12 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-            "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+            "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
             "dev": true,
             "dependencies": {
-                "@vitest/pretty-format": "3.2.4",
+                "@vitest/pretty-format": "3.2.6",
                 "loupe": "^3.1.4",
                 "tinyrainbow": "^2.0.0"
             },
@@ -2051,9 +2052,9 @@
             "dev": true
         },
         "node_modules/chai": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-5.2.1.tgz",
-            "integrity": "sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+            "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
             "dev": true,
             "dependencies": {
                 "assertion-error": "^2.0.1",
@@ -2095,9 +2096,9 @@
             }
         },
         "node_modules/check-error": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
-            "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+            "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
             "dev": true,
             "engines": {
                 "node": ">= 16"
@@ -3128,16 +3129,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-            "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "dev": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -3392,9 +3393,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -3785,10 +3786,20 @@
             "dev": true
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -4097,9 +4108,9 @@
             }
         },
         "node_modules/loupe": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.0.tgz",
-            "integrity": "sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+            "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
             "dev": true
         },
         "node_modules/lru-cache": {
@@ -5179,9 +5190,9 @@
             }
         },
         "node_modules/strip-literal": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.0.0.tgz",
-            "integrity": "sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+            "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
             "dev": true,
             "dependencies": {
                 "js-tokens": "^9.0.1"
@@ -5293,9 +5304,9 @@
             }
         },
         "node_modules/tinyspy": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.3.tgz",
-            "integrity": "sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+            "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
             "dev": true,
             "engines": {
                 "node": ">=14.0.0"
@@ -5483,9 +5494,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "6.4.2",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-            "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+            "version": "6.4.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+            "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
             "dev": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
@@ -5579,19 +5590,19 @@
             }
         },
         "node_modules/vitest": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-            "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+            "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
             "dev": true,
             "dependencies": {
                 "@types/chai": "^5.2.2",
-                "@vitest/expect": "3.2.4",
-                "@vitest/mocker": "3.2.4",
-                "@vitest/pretty-format": "^3.2.4",
-                "@vitest/runner": "3.2.4",
-                "@vitest/snapshot": "3.2.4",
-                "@vitest/spy": "3.2.4",
-                "@vitest/utils": "3.2.4",
+                "@vitest/expect": "3.2.6",
+                "@vitest/mocker": "3.2.6",
+                "@vitest/pretty-format": "^3.2.6",
+                "@vitest/runner": "3.2.6",
+                "@vitest/snapshot": "3.2.6",
+                "@vitest/spy": "3.2.6",
+                "@vitest/utils": "3.2.6",
                 "chai": "^5.2.0",
                 "debug": "^4.4.1",
                 "expect-type": "^1.2.1",
@@ -5621,8 +5632,8 @@
                 "@edge-runtime/vm": "*",
                 "@types/debug": "^4.1.12",
                 "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-                "@vitest/browser": "3.2.4",
-                "@vitest/ui": "3.2.4",
+                "@vitest/browser": "3.2.6",
+                "@vitest/ui": "3.2.6",
                 "happy-dom": "*",
                 "jsdom": "*"
             },


### PR DESCRIPTION
Regenerated frontend and test package-lock files after dependency updates, including Vite 6.4.3, Vitest 3.2.6, and js-yaml 4.3.0. The lockfile refresh also pulls in related transitive updates (notably chai/form-data/hasown family) to keep the toolchain current and dependency trees aligned.