### PR TITLE
feat: Add item history section to Item view

### DIFF
--- a/electrostoreFRONT/src/enums/ItemHistoryType.js
+++ b/electrostoreFRONT/src/enums/ItemHistoryType.js
@@ -1,0 +1,10 @@
+const ItemHistoryType = {
+	ItemCreated: 0,
+	ItemUpdated: 1,
+	ItemDeleted: 2,
+	StockAdded: 3,
+	StockRemoved: 4,
+	StockUpdated: 5,
+};
+
+export default ItemHistoryType;

--- a/electrostoreFRONT/src/enums/index.js
+++ b/electrostoreFRONT/src/enums/index.js
@@ -1,2 +1,3 @@
+export { default as ItemHistoryType } from "./ItemHistoryType.js";
 export { default as ProjetStatus } from "./ProjetStatus.js";
 export { default as UserRole } from "./UserRole.js";

--- a/electrostoreFRONT/src/locales/en/item.json
+++ b/electrostoreFRONT/src/locales/en/item.json
@@ -70,6 +70,15 @@
 	"DocumentType": "Type",
 	"DocumentDate": "Date",
 	"DocumentActions": "Actions",
+	"History": "History",
+	"HistoryDate": "Date",
+	"HistoryType": "Type",
+	"HistoryQuantityChange": "Quantity change",
+	"HistoryOldQuantity": "Old quantity",
+	"HistoryNewQuantity": "New quantity",
+	"HistoryBoxId": "Item Box Id",
+	"HistoryUser": "User",
+	"HistoryNotes": "Notes",
 	"Images": "Images",
 	"AddImage": "Add image",
 	"ImageLoading": "Loading",
@@ -102,5 +111,11 @@
 	"TagName": "Name",
 	"TagActions": "Actions",
 	"TagAdded": "Tag added",
-	"TagDeleted": "Tag deleted"
+	"TagDeleted": "Tag deleted",
+	"HistoryTypeItemCreated": "Item created",
+	"HistoryTypeItemUpdated": "Item updated",
+	"HistoryTypeItemDeleted": "Item deleted",
+	"HistoryTypeStockAdded": "Stock added",
+	"HistoryTypeStockRemoved": "Stock removed",
+	"HistoryTypeStockUpdated": "Stock updated"
 }

--- a/electrostoreFRONT/src/locales/fr/item.json
+++ b/electrostoreFRONT/src/locales/fr/item.json
@@ -70,6 +70,15 @@
 	"DocumentType": "Type",
 	"DocumentDate": "Date",
 	"DocumentActions": "Actions",
+	"History": "Historique",
+	"HistoryDate": "Date",
+	"HistoryType": "Type",
+	"HistoryQuantityChange": "Changement de quantité",
+	"HistoryOldQuantity": "Ancienne quantité",
+	"HistoryNewQuantity": "Nouvelle quantité",
+	"HistoryBoxId": "Id de la boîte d'articles",
+	"HistoryUser": "utilisateur",
+	"HistoryNotes": "Notes",
 	"Images": "Images",
 	"AddImage": "Ajouter une image",
 	"ImageLoading": "Chargement",
@@ -102,5 +111,11 @@
 	"TagName": "Nom",
 	"TagActions": "Actions",
 	"TagAdded": "Tag ajouté",
-	"TagDeleted": "Tag supprimé"
+	"TagDeleted": "Tag supprimé",
+	"HistoryTypeItemCreated": "Item créé",
+	"HistoryTypeItemUpdated": "Item mis à jour",
+	"HistoryTypeItemDeleted": "Item supprimé",
+	"HistoryTypeStockAdded": "Stock ajouté",
+	"HistoryTypeStockRemoved": "Stock retiré",
+	"HistoryTypeStockUpdated": "Stock mis à jour"
 }

--- a/electrostoreFRONT/src/stores/items.store.js
+++ b/electrostoreFRONT/src/stores/items.store.js
@@ -2,7 +2,7 @@ import { defineStore } from "pinia";
 
 import { fetchWrapper } from "@/helpers";
 
-import { useTagsStore, useStoresStore, useCommandsStore, useProjetsStore } from "@/stores";
+import { useTagsStore, useStoresStore, useCommandsStore, useProjetsStore, useUsersStore } from "@/stores";
 
 const baseUrl = `${import.meta.env.VITE_API_URL}`;
 
@@ -44,6 +44,10 @@ export const useItemsStore = defineStore("items",{
 		imagesURL: {},
 		thumbnailsURL: {},
 		imageEdition: {},
+
+		itemHistoryLoading: false,
+		itemHistoryTotalCount: {},
+		itemHistory: {},
 	}),
 	actions: {
 		async getItemByList(idResearch = [], expand = []) {
@@ -93,6 +97,12 @@ export const useItemsStore = defineStore("items",{
 					this.itemProjets[item.id_item] = {};
 					for (const itemProjet of item["projet_items"]) {
 						this.itemProjets[item.id_item][itemProjet.id_projet] = itemProjet;
+					}
+				}
+				if (expand.includes("item_history")) {
+					this.itemHistory[item.id_item] = {};
+					for (const itemHistory of item["item_history"]) {
+						this.itemHistory[item.id_item][itemHistory.id_item_history] = itemHistory;
 					}
 				}
 			}
@@ -151,6 +161,12 @@ export const useItemsStore = defineStore("items",{
 					this.itemProjets[item.id_item] = {};
 					for (const itemProjet of item["projet_items"]) {
 						this.itemProjets[item.id_item][itemProjet.id_projet] = itemProjet;
+					}
+				}
+				if (expand.includes("item_history")) {
+					this.itemHistory[item.id_item] = {};
+					for (const itemHistory of item["item_history"]) {
+						this.itemHistory[item.id_item][itemHistory.id_item_history] = itemHistory;
 					}
 				}
 			}
@@ -775,6 +791,51 @@ export const useItemsStore = defineStore("items",{
 			});
 			const url = URL.createObjectURL(response);
 			this.thumbnailsURL[id_img] = url;
+		},
+
+		async getItemHistoryByInterval(idItem, limit = 100, offset = 0, expand = [], filter = "", sort = "", clear = false) {
+			if (!this.itemHistory[idItem] || clear) {
+				this.itemHistory[idItem] = {};
+			}
+			this.itemHistoryLoading = true;
+			const usersStore = useUsersStore();
+			const offsetString = "offset=" + offset;
+			const limitString = "limit=" + limit;
+			const expandString = expand.map((id) => "expand=" + id.toString()).join("&");
+			const filterString = filter ? "filter=" + filter : "";
+			const sortString = sort ? "sort=" + sort : "";
+			const paramString = [offsetString, limitString, expandString, filterString, sortString].join("&");
+			const newItemHistoryList = await fetchWrapper.get({
+				url: `${baseUrl}/item/${idItem}/history?${paramString}`,
+				useToken: "access",
+			});
+			for (const itemHistory of newItemHistoryList["data"]) {
+				this.itemHistory[idItem][itemHistory.id_item_history] = itemHistory;
+				if (expand.includes("user")) {
+					usersStore.users[itemHistory.id_user] = itemHistory["user"];
+				}
+			}
+			this.itemHistoryTotalCount[idItem] = newItemHistoryList["pagination"]?.["total"] || 0;
+			this.itemHistoryLoading = false;
+			return [newItemHistoryList["pagination"]?.["nextOffset"] || 0, newItemHistoryList["pagination"]?.["hasMore"] || false];
+		},
+		async getItemHistoryById(idItem, id, expand = []) {
+			if (!this.itemHistory[idItem]) {
+				this.itemHistory[idItem] = {};
+			}
+			if (!this.itemHistory[idItem][id]) {
+				this.itemHistory[idItem][id] = {};
+			}
+			this.itemHistory[idItem][id].loading = true;
+			const usersStore = useUsersStore();
+			const expandString = expand.map((id) => "expand=" + id.toString()).join("&");
+			this.itemHistory[idItem][id] = await fetchWrapper.get({
+				url: `${baseUrl}/item/${idItem}/history/${id}?${expandString}`,
+				useToken: "access",
+			});
+			if (expand.includes("user")) {
+				usersStore.users[this.itemHistory[idItem][id].id_user] = this.itemHistory[idItem][id]["user"];
+			}
 		},
 	},
 });

--- a/electrostoreFRONT/src/views/ItemView.vue
+++ b/electrostoreFRONT/src/views/ItemView.vue
@@ -16,7 +16,9 @@ const preset = ref(route.query.preset || null);
 
 import { downloadFile, viewFile } from "@/utils";
 
-import { useConfigsStore, useItemsStore, useTagsStore, useStoresStore, useCommandsStore, useProjetsStore, useAuthStore } from "@/stores";
+import { ItemHistoryType } from "@/enums";
+
+import { useConfigsStore, useItemsStore, useTagsStore, useStoresStore, useCommandsStore, useProjetsStore, useAuthStore, useUsersStore } from "@/stores";
 const configsStore = useConfigsStore();
 const itemsStore = useItemsStore();
 const tagsStore = useTagsStore();
@@ -24,6 +26,7 @@ const storesStore = useStoresStore();
 const commandsStore = useCommandsStore();
 const projetsStore = useProjetsStore();
 const authStore = useAuthStore();
+const usersStore = useUsersStore();
 
 const formContainer = ref(null);
 
@@ -304,6 +307,11 @@ function tagDelete(id_tag) {
 	}
 }
 
+// item history enum
+const projetTypeStatus = ref({ [ItemHistoryType.ItemCreated]: t("item.HistoryTypeItemCreated"), [ItemHistoryType.ItemUpdated]: t("item.HistoryTypeItemUpdated"),
+	[ItemHistoryType.ItemDeleted]: t("item.HistoryTypeItemDeleted"), [ItemHistoryType.StockAdded]: t("item.HistoryTypeStockAdded"),
+	[ItemHistoryType.StockRemoved]: t("item.HistoryTypeStockRemoved"), [ItemHistoryType.StockUpdated]: t("item.HistoryTypeStockUpdated") });
+
 const schemaBox = Yup.object().shape({
 	qte_item_box: Yup.number()
 		.required(t("item.BoxQuantityRequired"))
@@ -441,6 +449,16 @@ const labelTableauDocument = ref([
 			class: "px-3 py-1 bg-red-500 text-white rounded-lg hover:bg-red-600",
 		},
 	] },
+]);
+const labelTableauHistory = ref([
+	{ label: "item.HistoryDate", sortable: true, key: "created_at", valueKey: "created_at", type: "datetime" },
+	{ label: "item.HistoryType", sortable: true, key: "type", valueKey: "type", type: "enum", options: projetTypeStatus },
+	{ label: "item.HistoryQuantityChange", sortable: true, key: "quantity_change", valueKey: "quantity_change", type: "number" },
+	{ label: "item.HistoryOldQuantity", sortable: true, key: "old_quantity", valueKey: "old_quantity", type: "number" },
+	{ label: "item.HistoryNewQuantity", sortable: true, key: "new_quantity", valueKey: "new_quantity", type: "number" },
+	{ label: "item.HistoryBoxId", sortable: true, key: "id_box", valueKey: "id_box", type: "number" },
+	{ label: "item.HistoryUser", sortable: true, key: "User.email_user", valueKey: "email_user", type: "text", storeRessourceId: 1, sourceKey: "id_user" },
+	{ label: "item.HistoryNotes", sortable: false, key: "notes", valueKey: "notes", type: "text" },
 ]);
 const labelTableauBox = ref([
 	{ label: "item.BoxId", sortable: true, key: "id_box", valueKey: "id_box", type: "number" },
@@ -638,6 +656,18 @@ document.querySelector("#view").classList.add("overflow-y-scroll");
 					:total-count="Number(itemsStore.itemProjetsTotalCount[itemId])"
 					:fetch-function="itemId !== 'new' ? (limit, offset, expand, filter, sort, clear) => itemsStore.getItemProjetByInterval(itemId, limit, offset, expand, filter, sort, clear) : undefined"
 					:tableau-css="{ component: 'max-h-64' }"
+				/>
+			</template>
+		</CollapsibleSection>
+		<CollapsibleSection title="item.History"
+			:total-count="Number(itemsStore.itemHistoryTotalCount[itemId] || 0)" :permission="itemId !=='new'">
+			<template #append-row>
+				<Tableau :labels="labelTableauHistory" :meta="{ key: 'id_item_history', expand: ['user'] }"
+					:store-data="[itemsStore.itemHistory[itemId], usersStore.users]"
+					:loading="itemsStore.itemHistoryLoading"
+					:total-count="Number(itemsStore.itemHistoryTotalCount[itemId])"
+					:fetch-function="itemId !== 'new' ? (limit, offset, expand, filter, sort, clear) => itemsStore.getItemHistoryByInterval(itemId, limit, offset, expand, filter, sort, clear) : undefined"
+					:tableau-css="{ component: 'max-h-64', tr: 'transition duration-150 ease-in-out hover:bg-gray-200 even:bg-gray-10' }"
 				/>
 			</template>
 		</CollapsibleSection>


### PR DESCRIPTION
Introduces item history support across the frontend: a new `ItemHistoryType` enum, localized history labels/types in EN/FR, and item store state/actions to fetch history lists and single entries (with optional expanded users). `ItemView` now renders a History table with sortable columns and user resolution via `usersStore`.