### PR TITLE
feat: Form field type fetch-select and readonly

### DIFF
--- a/docs/generator/js/generators.js
+++ b/docs/generator/js/generators.js
@@ -569,7 +569,7 @@ function generateApiAppsettings(config) {
 
     if (config.useMQTT) {
         settings.MQTT = {
-            "Server": "mqtt",
+            "Server": "electrostore-mqtt",
             "Port": 1883,
             "Username": config.mqtt.user,
             "Password": config.useVault ? "{{vault:mqtt_password}}" : config.mqtt.password

--- a/docs/generator/js/generators.js
+++ b/docs/generator/js/generators.js
@@ -961,7 +961,7 @@ function generateWorkerAppsettings(config) {
 
     if (config.useMQTT) {
         settings.Mqtt = {
-            "Host": "mqtt",
+            "Host": "electrostore-mqtt",
             "Port": "1883",
             "Username": config.mqtt.user,
             "Password": config.useVault ? "{{vault:mqtt_password}}" : config.mqtt.password,

--- a/electrostoreAPI/Controllers/CommandController.cs
+++ b/electrostoreAPI/Controllers/CommandController.cs
@@ -22,7 +22,7 @@ namespace ElectrostoreAPI.Controllers
         [HttpGet]
         [Authorize(Policy = "AccessToken")]
         public async Task<ActionResult<PaginatedResponseDto<ReadExtendedCommandDto>>> GetCommands([FromQuery] int limit = 100, [FromQuery] int offset = 0,
-        [FromQuery, SwaggerParameter(Description = "(Optional) Fields to expand. Possible values: 'commands_commentaires', 'commands_documents', 'commands_history', 'commands_items'. Multiple values can be specified by separating them with ','.")] List<string>? expand = null,
+        [FromQuery, SwaggerParameter(Description = "(Optional) Fields to expand. Possible values: 'commands_commentaires', 'commands_documents', 'commands_history', 'commands_items', 'carrier'. Multiple values can be specified by separating them with ','.")] List<string>? expand = null,
         [FromQuery, SwaggerParameter(Description = "(Optional) Fields to select list of ID to research in the base. Multiple values can be specified by separating them with ','.")] List<int>? idResearch = null,
         [FromQuery, SwaggerParameter(Description = "(Optional) RSQL string to filter results. Example: 'nom_command=like=example'.")] string? filter = null,
         [FromQuery, SwaggerParameter(Description = "(Optional) Sort string to order results. Example: 'nom_command,asc' or 'nom_command,desc'.")] string? sort = null)
@@ -36,7 +36,7 @@ namespace ElectrostoreAPI.Controllers
         [HttpGet("{id_command}")]
         [Authorize(Policy = "AccessToken")]
         public async Task<ActionResult<ReadExtendedCommandDto>> GetCommandById([FromRoute] int id_command,
-        [FromQuery, SwaggerParameter(Description = "(Optional) Fields to expand. Possible values: 'commands_commentaires', 'commands_documents', 'commands_history', 'commands_items'. Multiple values can be specified by separating them with ','.")] List<string>? expand = null)
+        [FromQuery, SwaggerParameter(Description = "(Optional) Fields to expand. Possible values: 'commands_commentaires', 'commands_documents', 'commands_history', 'commands_items', 'carrier'. Multiple values can be specified by separating them with ','.")] List<string>? expand = null)
         {
             var command = await _commandService.GetCommandById(id_command, expand);
             return Ok(command);

--- a/electrostoreAPI/Services/CommandService/CommandService.cs
+++ b/electrostoreAPI/Services/CommandService/CommandService.cs
@@ -76,7 +76,8 @@ public class CommandService : ICommandService
                 CommandsCommentaires = expand != null && expand.Contains("commands_commentaires") ? c.CommandsCommentaires.Take(20).ToList() : null,
                 CommandsDocuments = expand != null && expand.Contains("commands_documents") ? c.CommandsDocuments.Take(20).ToList() : null,
                 CommandsHistory = expand != null && expand.Contains("commands_history") ? c.CommandsHistory.Take(20).ToList() : null,
-                CommandsItems = expand != null && expand.Contains("commands_items") ? c.CommandsItems.Take(20).ToList() : null
+                CommandsItems = expand != null && expand.Contains("commands_items") ? c.CommandsItems.Take(20).ToList() : null,
+                Carrier = expand != null && expand.Contains("carrier") ? c.Carrier : null
             })
             .ToListAsync();
         return new PaginatedResponseDto<ReadExtendedCommandDto>
@@ -90,7 +91,8 @@ public class CommandService : ICommandService
                     commands_commentaires = _mapper.Map<IEnumerable<ReadCommandCommentaireDto>>(c.CommandsCommentaires),
                     commands_documents = _mapper.Map<IEnumerable<ReadCommandDocumentDto>>(c.CommandsDocuments),
                     commands_history = _mapper.Map<IEnumerable<ReadCommandHistoryDto>>(c.CommandsHistory),
-                    commands_items = _mapper.Map<IEnumerable<ReadCommandItemDto>>(c.CommandsItems)
+                    commands_items = _mapper.Map<IEnumerable<ReadCommandItemDto>>(c.CommandsItems),
+                    carrier = c.Command.Carrier != null ? _mapper.Map<ReadCarrierDto>(c.Command.Carrier) : null
                 };
             }).ToList(),
             pagination = new PaginationDto

--- a/electrostoreFRONT/src/components/FormContainer.vue
+++ b/electrostoreFRONT/src/components/FormContainer.vue
@@ -129,6 +129,50 @@
 								</Field>
 								<span class="text-red-500 h-5 w-full text-sm">{{ errors[field.key] || ' ' }}</span>
 							</template>
+							<template v-else-if="field.type === 'fetch-select'">
+								<Field :name="field.key" v-model="storeData[field.key]" type="hidden" />
+								<div class="relative">
+									<input
+										:id="`form-input-${this.$.uid}-${field.key}`"
+										:ref="`fetch-select-input-${field.key}`"
+										type="text"
+										:value="getFetchSelectInputText(field)"
+										@input="handleFetchSelectInput(field, $event)"
+										@focus="openFetchSelect(field, $event)"
+										@blur="closeFetchSelectDelayed(field.key)"
+										class="border border-gray-300 rounded px-2 py-1 w-full pr-7 focus:outline-none focus:ring focus:ring-blue-300"
+										:class="{ 'border-red-500': errors[field.key] }"
+										:placeholder="field.placeholder ? $t(field.placeholder) : ''"
+										:disabled="(!permission) || (field?.enableCondition && !evaluateCondition(field.enableCondition)) || field?.loading"
+									/>
+									<div class="absolute inset-y-0 right-0 flex items-center pr-2 pointer-events-none">
+										<svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+										</svg>
+									</div>
+								</div>
+								<Teleport to="body">
+									<div
+										v-show="isFetchSelectOpen(field.key)"
+										:ref="`fetch-select-menu-${field.key}`"
+										:style="getFetchSelectStyle(field.key)"
+										class="fixed z-[9999] bg-white border border-gray-300 rounded shadow-lg max-h-60 overflow-y-auto"
+									>
+										<div
+											v-for="[value, label] in getFetchSelectOptions(field)"
+											:key="value"
+											@mousedown.prevent="selectFetchOption(field, value, label)"
+											class="px-3 py-2 hover:bg-gray-50 cursor-pointer text-sm"
+										>
+											{{ label }}
+										</div>
+										<div v-if="getFetchSelectOptions(field).length === 0" class="px-3 py-2 text-sm text-gray-400 italic">
+											Aucun résultat
+										</div>
+									</div>
+								</Teleport>
+								<span class="text-red-500 h-5 w-full text-sm">{{ errors[field.key] || ' ' }}</span>
+							</template>
 							<template v-else-if="field.type === 'textarea'">
 								<Field :id="`form-input-${this.$.uid}-${field.key}`" :name="field.key" as="textarea" v-model="storeData[field.key]" :rows="field.rows || 3"
 									class="border border-gray-300 rounded px-2 py-1 w-full focus:outline-none focus:ring focus:ring-blue-300"
@@ -192,6 +236,8 @@
 
 <script>
 import { Form, Field } from "vee-validate";
+import { debounce } from "lodash-es";
+import { buildRSQLFilter, buildRSQLSort } from "@/utils";
 export default {
 	name: "FormContainer",
 	props: {
@@ -239,6 +285,9 @@ export default {
 		labelsShown() {
 			return this.labels.filter((field) => !field?.showCondition || this.evaluateCondition(field.showCondition));
 		},
+	},
+	created() {
+		this._fetchSelectDebouncers = {};
 	},
 	components: {
 		Form,
@@ -324,6 +373,16 @@ export default {
 					}
 				}
 			});
+			// Mettre à jour les positions des fetch-select ouverts
+			Object.keys(this.fetchSelectState).forEach((key) => {
+				if (this.fetchSelectState[key]?.isOpen) {
+					const inputRef = `fetch-select-input-${key}`;
+					const input = this.$refs[inputRef];
+					if (input) {
+						this.updateFetchSelectPosition(key, Array.isArray(input) ? input[0] : input);
+					}
+				}
+			});
 		},
 		handleClickOutside(event) {
 			// Fermer les dropdowns si on clique en dehors
@@ -368,17 +427,106 @@ export default {
 				this.recalculateDropdownPosition(key);
 			}
 		},
-		recalculateDropdownPosition(key) {
-			// Attendre que le DOM soit mis à jour avec le nouvel état
-			this.$nextTick(() => {
-				if (this.dropdownOpen[key]) {
-					const buttonRef = `dropdown-button-${key}`;
-					const button = this.$refs[buttonRef];
-					if (button) {
-						this.updateDropdownPosition(key, Array.isArray(button) ? button[0] : button);
+		initFetchSelectState(field) {
+			const key = field.key;
+			if (!this.fetchSelectState[key]) {
+				let initialText = "";
+				if (this.storeData[key] !== undefined && this.storeData[key] !== null && this.storeData[key] !== "" && field.fetchStore) {
+					const fetchValueKey = field.fetchValueKey || field.fetchStoreKey;
+					const found = Object.values(field.fetchStore).find((item) => String(item[fetchValueKey]) === String(this.storeData[key]));
+					if (found) {
+						initialText = found[field.fetchStoreKey];
 					}
 				}
+				this.fetchSelectState[key] = { inputText: initialText, isOpen: false, position: null };
+			}
+		},
+		getFetchSelectInputText(field) {
+			this.initFetchSelectState(field);
+			return this.fetchSelectState[field.key].inputText;
+		},
+		isFetchSelectOpen(key) {
+			return this.fetchSelectState[key]?.isOpen || false;
+		},
+		getFetchSelectStyle(key) {
+			const pos = this.fetchSelectState[key]?.position;
+			if (!pos) {
+				return {};
+			}
+			return {
+				top: `${pos.top + 4}px`,
+				left: `${pos.left}px`,
+				width: `${pos.width}px`,
+			};
+		},
+		updateFetchSelectPosition(key, inputEl) {
+			if (!inputEl) {
+				return;
+			}
+			const rect = inputEl.getBoundingClientRect();
+			this.fetchSelectState[key].position = {
+				top: rect.bottom + window.scrollY,
+				left: rect.left + window.scrollX,
+				width: rect.width,
+			};
+		},
+		async openFetchSelect(field, event) {
+			this.initFetchSelectState(field);
+			this.fetchSelectState[field.key].isOpen = true;
+			this.fetchSelectState[field.key].inputText = "";
+			await this.doFetchSelectSearch(field);
+			this.$nextTick(() => {
+				this.updateFetchSelectPosition(field.key, event.target);
 			});
+		},
+		closeFetchSelectDelayed(key) {
+			setTimeout(() => {
+				if (this.fetchSelectState[key]) {
+					this.fetchSelectState[key].isOpen = false;
+				}
+			}, 200);
+		},
+		selectFetchOption(field, value, label) {
+			this.storeData[field.key] = value;
+			this.fetchSelectState[field.key].inputText = label;
+			this.fetchSelectState[field.key].isOpen = false;
+		},
+		handleFetchSelectInput(field, event) {
+			this.initFetchSelectState(field);
+			this.fetchSelectState[field.key].inputText = event.target.value;
+			this.fetchSelectState[field.key].isOpen = true;
+			if (!this._fetchSelectDebouncers[field.key]) {
+				this._fetchSelectDebouncers[field.key] = debounce(async(f) => {
+					await this.doFetchSelectSearch(f);
+					this.$nextTick(() => {
+						const inputRef = `fetch-select-input-${f.key}`;
+						const input = this.$refs[inputRef];
+						if (input) {
+							this.updateFetchSelectPosition(f.key, Array.isArray(input) ? input[0] : input);
+						}
+					});
+				}, 300);
+			}
+			this._fetchSelectDebouncers[field.key](field);
+		},
+		async doFetchSelectSearch(field) {
+			if (!field.fetchFunction) {
+				return;
+			}
+			const inputText = this.fetchSelectState[field.key]?.inputText || "";
+			const filter = [{ key: field.fetchStoreKey, compareMethod: "=like=", value: inputText }];
+			const sort = { key: field.fetchStoreKey, order: "asc" };
+			await field.fetchFunction(10, 0, [], buildRSQLFilter(filter), buildRSQLSort(sort), false);
+		},
+		getFetchSelectOptions(field) {
+			if (!field.fetchStore) {
+				return [];
+			}
+			const fetchValueKey = field.fetchValueKey || field.fetchStoreKey;
+			return Object.values(field.fetchStore).filter((item) => {
+				const inputText = this.fetchSelectState[field.key]?.inputText || "";
+				return String(item[field.fetchStoreKey]).toLowerCase().includes(inputText.toLowerCase());
+			}).map((item) => [item[fetchValueKey], item[field.fetchStoreKey]]);
 		},
 		getSortedOptions(field) {
 			if (!field.options) {
@@ -416,6 +564,7 @@ export default {
 			showPassword: false,
 			dropdownOpen: {},
 			dropdownPositions: {},
+			fetchSelectState: {},
 		};
 	},
 	mounted() {

--- a/electrostoreFRONT/src/components/FormContainer.vue
+++ b/electrostoreFRONT/src/components/FormContainer.vue
@@ -14,6 +14,10 @@
 						<span v-if="field.label" class="font-semibold sm:min-w-[150px]" :for="`form-input-${this.$.uid}-${field.key}`">{{ $t(field.label) }}</span>
 						<span v-else class="font-semibold sm:min-w-[150px]" :for="`form-input-${this.$.uid}-${field.key}`">{{ field.text }}</span>
 					</template>
+					<template v-else-if="field.type === 'readonly'">
+						<span v-if="field.label" class="font-semibold sm:min-w-[150px]" :for="`form-input-${this.$.uid}-${field.key}`">{{ $t(field.label) }}</span>
+						<span v-else class="font-semibold sm:min-w-[150px]" :for="`form-input-${this.$.uid}-${field.key}`">{{ storeData[field.key] }}</span>
+					</template>
 					<template v-else>
 						<label v-if="field.label" class="font-semibold sm:min-w-[150px]" :for="`form-input-${this.$.uid}-${field.key}`">{{ $t(field.label) }}</label>
 						<label v-else class="font-semibold sm:min-w-[150px]" :for="`form-input-${this.$.uid}-${field.key}`">{{ field.text }}</label>
@@ -139,7 +143,7 @@
 										:value="getFetchSelectInputText(field)"
 										@input="handleFetchSelectInput(field, $event)"
 										@focus="openFetchSelect(field, $event)"
-										@blur="closeFetchSelectDelayed(field.key)"
+										@blur="closeFetchSelect(field.key)"
 										class="border border-gray-300 rounded px-2 py-1 w-full pr-7 focus:outline-none focus:ring focus:ring-blue-300"
 										:class="{ 'border-red-500': errors[field.key] }"
 										:placeholder="field.placeholder ? $t(field.placeholder) : ''"
@@ -442,8 +446,7 @@ export default {
 			}
 		},
 		getFetchSelectInputText(field) {
-			this.initFetchSelectState(field);
-			return this.fetchSelectState[field.key].inputText;
+			return Object.values(field.fetchStore).find((item) => String(item[field.fetchValueKey || field.fetchStoreKey]) === String(this.storeData[field.key]))?.[field.fetchStoreKey] || "";
 		},
 		isFetchSelectOpen(key) {
 			return this.fetchSelectState[key]?.isOpen || false;
@@ -479,17 +482,21 @@ export default {
 				this.updateFetchSelectPosition(field.key, event.target);
 			});
 		},
-		closeFetchSelectDelayed(key) {
-			setTimeout(() => {
-				if (this.fetchSelectState[key]) {
-					this.fetchSelectState[key].isOpen = false;
-				}
-			}, 200);
+		closeFetchSelect(key) {
+			if (this.fetchSelectState[key]) {
+				this.fetchSelectState[key].isOpen = false;
+			}
 		},
 		selectFetchOption(field, value, label) {
 			this.storeData[field.key] = value;
 			this.fetchSelectState[field.key].inputText = label;
 			this.fetchSelectState[field.key].isOpen = false;
+			this.$nextTick(() => {
+				const input = this.$refs[`fetch-select-input-${field.key}`];
+				if (input) {
+					input[0].blur();
+				}
+			});
 		},
 		handleFetchSelectInput(field, event) {
 			this.initFetchSelectState(field);

--- a/electrostoreFRONT/src/stores/commands.store.js
+++ b/electrostoreFRONT/src/stores/commands.store.js
@@ -2,7 +2,7 @@ import { defineStore } from "pinia";
 
 import { fetchWrapper } from "@/helpers";
 
-import { useUsersStore, useItemsStore } from "@/stores";
+import { useUsersStore, useItemsStore, useCarriersStore } from "@/stores";
 
 const baseUrl = `${import.meta.env.VITE_API_URL}`;
 
@@ -71,6 +71,12 @@ export const useCommandsStore = defineStore("commands",{
 						this.items[command.id_command][item.id_item] = item;
 					}
 				}
+				if (expand.includes("carrier")) {
+					if (command.carrier) {
+						const carriersStore = useCarriersStore();
+						carriersStore.carriers[command.id_carrier] = command.carrier;
+					}
+				}
 			}
 			this.commandsLoading = false;
 		},
@@ -118,6 +124,12 @@ export const useCommandsStore = defineStore("commands",{
 						this.items[command.id_command][item.id_item] = item;
 					}
 				}
+				if (expand.includes("carrier")) {
+					if (command.carrier) {
+						const carriersStore = useCarriersStore();
+						carriersStore.carriers[command.id_carrier] = command.carrier;
+					}
+				}
 			}
 			this.commandsTotalCount = newCommandList["pagination"]?.["total"] || 0;
 			this.commandsLoading = false;
@@ -158,6 +170,12 @@ export const useCommandsStore = defineStore("commands",{
 				this.items[id] = {};
 				for (const item of this.commands[id].commands_items) {
 					this.items[id][item.id_item] = item;
+				}
+			}
+			if (expand.includes("carrier")) {
+				if (this.commands[id].carrier) {
+					const carriersStore = useCarriersStore();
+					carriersStore.carriers[this.commands[id].id_carrier] = this.commands[id].carrier;
 				}
 			}
 		},

--- a/electrostoreFRONT/src/views/CommandView.vue
+++ b/electrostoreFRONT/src/views/CommandView.vue
@@ -31,10 +31,10 @@ const authStore = useAuthStore();
 const formContainer = ref(null);
 
 async function fetchAllData() {
-	if (Object.keys(carriersStore.carriers).length === 0) {
-		carriersStore.getCarrierByInterval(200, 0, "", "", false);
-	}
 	if (commandId.value === "new") {
+		if (Object.keys(carriersStore.carriers).length === 0) {
+			carriersStore.getCarrierByInterval(200, 0, "", "", false);
+		}
 		loadToEdition(commandId.value);
 		if (preset.value) {
 			preset.value.split(";").forEach((pair) => {
@@ -49,7 +49,7 @@ async function fetchAllData() {
 			loading: true,
 		};
 		try {
-			await commandsStore.getCommandById(commandId.value);
+			await commandsStore.getCommandById(commandId.value, ["carrier"]);
 		} catch {
 			delete commandsStore.commands[commandId.value];
 			addNotification({ message: t("command.NotFound"), type: "error" });
@@ -241,13 +241,6 @@ const trackingHistory = computed(() => {
 	}
 	return result;
 });
-const carrierOptions = computed(() =>
-	Object.fromEntries(
-		Object.values(carriersStore.carriers)
-			.filter((c) => c && c.id_carrier)
-			.map((c) => [c.id_carrier, c.name ?? `Carrier #${c.id_carrier}`]),
-	),
-);
 const commandSave = async() => {
 	try {
 		const validationResults = await Promise.all([
@@ -562,12 +555,12 @@ const labelForm = computed(() => [
 		carriersStore.getCarrierByInterval(limit, offset, filter, sort, clear),
 	fetchStore: carriersStore.carriers, fetchValueKey: "id_carrier", fetchStoreKey: "name",
 	},
-	{ key: "is_tracking_requested", label: "command.IsTrackingRequested", type: "computed" },
-	{ key: "is_tracking_validated", label: "command.IsTrackingValidated", type: "computed" },
-	{ key: "is_active", label: "command.IsActive", type: "computed" },
-	{ key: "shipper_adress", label: "command.ShipperAddress", type: "computed" },
-	{ key: "recipient_adress", label: "command.RecipientAddress", type: "computed" },
-	{ key: "last_status", label: "command.LastStatus", type: "computed" },
+	{ key: "is_tracking_requested", label: "command.IsTrackingRequested", type: "checkbox", enableCondition: "false" },
+	{ key: "is_tracking_validated", label: "command.IsTrackingValidated", type: "checkbox", enableCondition: "false" },
+	{ key: "is_active", label: "command.IsActive", type: "checkbox", enableCondition: "false" },
+	{ key: "shipper_adress", label: "command.ShipperAddress", type: "readonly" },
+	{ key: "recipient_adress", label: "command.RecipientAddress", type: "readonly" },
+	{ key: "last_status", label: "command.LastStatus", type: "readonly" },
 ]);
 const labelTableauDocument = ref([
 	{ label: "command.DocumentName", sortable: true, key: "name_command_document", valueKey: "name_command_document", type: "text", canEdit: true },

--- a/openapi/swagger.json
+++ b/openapi/swagger.json
@@ -924,7 +924,7 @@
           {
             "name": "expand",
             "in": "query",
-            "description": "(Optional) Fields to expand. Possible values: 'commands_commentaires', 'commands_documents', 'commands_history', 'commands_items'. Multiple values can be specified by separating them with ','.",
+            "description": "(Optional) Fields to expand. Possible values: 'commands_commentaires', 'commands_documents', 'commands_history', 'commands_items', 'carrier'. Multiple values can be specified by separating them with ','.",
             "schema": {
               "type": "array",
               "items": {
@@ -1049,7 +1049,7 @@
           {
             "name": "expand",
             "in": "query",
-            "description": "(Optional) Fields to expand. Possible values: 'commands_commentaires', 'commands_documents', 'commands_history', 'commands_items'. Multiple values can be specified by separating them with ','.",
+            "description": "(Optional) Fields to expand. Possible values: 'commands_commentaires', 'commands_documents', 'commands_history', 'commands_items', 'carrier'. Multiple values can be specified by separating them with ','.",
             "schema": {
               "type": "array",
               "items": {


### PR DESCRIPTION
introduces several enhancements and fixes across the backend and frontend, primarily focused on improving the handling and display of carrier data in commands, and adding a new "fetch-select" input type to form components. It also refines the way read-only and computed fields are rendered in forms. Additionally, MQTT server hostnames are updated for consistency.
