### PR TITLE
refactor: rework pr ci

### DIFF
--- a/.github/workflows/PRtests.yml
+++ b/.github/workflows/PRtests.yml
@@ -1,0 +1,111 @@
+name: tests PR
+
+on:
+  pull_request:
+
+jobs:
+  detect-changes:
+    name: Detect Modified Directories
+    runs-on: ubuntu-latest
+    outputs:
+      api: ${{ steps.filter.outputs.api }}
+      cron: ${{ steps.filter.outputs.cron }}
+      ia: ${{ steps.filter.outputs.ia }}
+      front: ${{ steps.filter.outputs.front }}
+      notif: ${{ steps.filter.outputs.notif }}
+      worker: ${{ steps.filter.outputs.worker }}
+      testAPI: ${{ steps.filter.outputs.testAPI }}
+      testCRON: ${{ steps.filter.outputs.testCRON }}
+      testIA: ${{ steps.filter.outputs.testIA }}
+      testFRONT: ${{ steps.filter.outputs.testFRONT }}
+      testNOTIF: ${{ steps.filter.outputs.testNOTIF }}
+      testWORKER: ${{ steps.filter.outputs.testWORKER }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Filter changed files
+        id: filter
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            api: 'electrostoreAPI/**'
+            cron: 'electrostoreCRON/**'
+            ia: 'electrostoreIA/**'
+            front: 'electrostoreFRONT/**'
+            notif: 'electrostoreNOTIF/**'
+            worker: 'electrostoreWORKER/**'
+            testAPI: 'tests/electrostoreAPI/**'
+            testCRON: 'tests/electrostoreCRON/**'
+            testIA: 'tests/electrostoreIA/**'
+            testFRONT: 'tests/electrostoreFRONT/**'
+            testNOTIF: 'tests/electrostoreNOTIF/**'
+            testWORKER: 'tests/electrostoreWORKER/**'
+  
+  test-api:
+    name: tests - API
+    needs: detect-changes
+    if: needs.detect-changes.outputs.api == 'true' || needs.detect-changes.outputs.testAPI == 'true'
+    uses: ./.github/workflows/PRtestsAPI.yml
+    with:
+      branch: ${{ github.head_ref }}
+    permissions:
+      packages: write
+      contents: read
+
+  test-cron:
+    name: tests - CRON
+    needs: detect-changes
+    if: needs.detect-changes.outputs.cron == 'true' || needs.detect-changes.outputs.testCRON == 'true'
+    uses: ./.github/workflows/PRtestsCRON.yml
+    with:
+      branch: ${{ github.head_ref }}
+    permissions:
+      packages: write
+      contents: read
+  
+  test-ia:
+    name: tests - IA
+    needs: detect-changes
+    if: needs.detect-changes.outputs.ia == 'true' || needs.detect-changes.outputs.testIA == 'true'
+    uses: ./.github/workflows/PRtestsIA.yml
+    with:
+      branch: ${{ github.head_ref }}
+    permissions:
+      packages: write
+      contents: read
+
+  test-front:
+    name: tests - FRONT
+    needs: detect-changes
+    if: needs.detect-changes.outputs.front == 'true' || needs.detect-changes.outputs.testFRONT == 'true'
+    uses: ./.github/workflows/PRtestsFRONT.yml
+    with:
+      branch: ${{ github.head_ref }}
+    permissions:
+      packages: write
+      contents: read
+
+  test-notif:
+    name: tests - NOTIF
+    needs: detect-changes
+    if: needs.detect-changes.outputs.notif == 'true' || needs.detect-changes.outputs.testNOTIF == 'true'
+    uses: ./.github/workflows/PRtestsNOTIF.yml
+    with:
+      branch: ${{ github.head_ref }}
+    permissions:
+      packages: write
+      contents: read
+
+  test-worker:
+    name: tests - WORKER
+    needs: detect-changes
+    if: needs.detect-changes.outputs.worker == 'true' || needs.detect-changes.outputs.testWORKER == 'true'
+    uses: ./.github/workflows/PRtestsWORKER.yml
+    with:
+      branch: ${{ github.head_ref }}
+    permissions:
+      packages: write
+      contents: read

--- a/.github/workflows/PRtestsAPI.yml
+++ b/.github/workflows/PRtestsAPI.yml
@@ -1,10 +1,12 @@
 name: tests PR API
 
 on:
-  pull_request:
-    paths:
-      - "electrostoreAPI/**"
-      - "tests/electrostoreAPI/**"
+  workflow_call:
+    inputs:
+      branch:
+        description: 'The branch that triggered this workflow.'
+        required: true
+        type: string
 
 jobs:
   test-api:
@@ -17,6 +19,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
+      with:
+        ref: ${{ inputs.branch }}
     - name: Set up C#
       uses: actions/setup-dotnet@v5
       with:

--- a/.github/workflows/PRtestsCRON.yml
+++ b/.github/workflows/PRtestsCRON.yml
@@ -1,10 +1,12 @@
 name: tests PR CRON
 
 on:
-  pull_request:
-    paths:
-      - "electrostoreCRON/**"
-      - "tests/electrostoreCRON/**"
+  workflow_call:
+    inputs:
+      branch:
+        description: 'The branch that triggered this workflow.'
+        required: true
+        type: string
 
 jobs:
   test-cron:
@@ -17,6 +19,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
+      with:
+        ref: ${{ inputs.branch }}
     - name: Set up C#
       uses: actions/setup-dotnet@v5
       with:

--- a/.github/workflows/PRtestsFRONT.yml
+++ b/.github/workflows/PRtestsFRONT.yml
@@ -1,10 +1,12 @@
 name: tests PR FRONT
 
 on:
-  pull_request:
-    paths:
-      - "electrostoreFRONT/**"
-      - "tests/electrostoreFRONT/**"
+  workflow_call:
+    inputs:
+      branch:
+        description: 'The branch that triggered this workflow.'
+        required: true
+        type: string
 
 jobs:
   test-front:
@@ -17,6 +19,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v7
+      with:
+        ref: ${{ inputs.branch }}
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:

--- a/.github/workflows/PRtestsIA.yml
+++ b/.github/workflows/PRtestsIA.yml
@@ -1,10 +1,12 @@
 name: tests PR IA
 
 on:
-  pull_request:
-    paths:
-      - "electrostoreIA/**"
-      - "tests/electrostoreIA/**"
+  workflow_call:
+    inputs:
+      branch:
+        description: 'The branch that triggered this workflow.'
+        required: true
+        type: string
 
 jobs:
   test-IA:
@@ -17,6 +19,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
+      with:
+        ref: ${{ inputs.branch }}
     - name: Set up C#
       uses: actions/setup-dotnet@v5
       with:

--- a/.github/workflows/PRtestsNOTIF.yml
+++ b/.github/workflows/PRtestsNOTIF.yml
@@ -1,10 +1,12 @@
 name: tests PR NOTIF
 
 on:
-  pull_request:
-    paths:
-      - "electrostoreNOTIF/**"
-      - "tests/electrostoreNOTIF/**"
+  workflow_call:
+    inputs:
+      branch:
+        description: 'The branch that triggered this workflow.'
+        required: true
+        type: string
 
 jobs:
   test-notif:
@@ -17,6 +19,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
+      with:
+        ref: ${{ inputs.branch }}
     - name: Set up C#
       uses: actions/setup-dotnet@v5
       with:

--- a/.github/workflows/PRtestsWORKER.yml
+++ b/.github/workflows/PRtestsWORKER.yml
@@ -1,10 +1,12 @@
 name: tests PR WORKER
 
 on:
-  pull_request:
-    paths:
-      - "electrostoreWORKER/**"
-      - "tests/electrostoreWORKER/**"
+  workflow_call:
+    inputs:
+      branch:
+        description: 'The branch that triggered this workflow.'
+        required: true
+        type: string
 
 jobs:
   test-worker:
@@ -17,6 +19,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
+      with:
+        ref: ${{ inputs.branch }}
     - name: Set up C#
       uses: actions/setup-dotnet@v5
       with:


### PR DESCRIPTION
This pull request refactors the GitHub Actions CI workflow for pull requests by introducing a modular and dynamic approach to running tests. Instead of running all test jobs for every PR, the workflow now detects which directories were modified and only triggers the relevant test suites. This change improves CI efficiency and maintainability. The individual test workflows have also been updated to support this new modular invocation.

**Workflow orchestration improvements:**

* Added a new main workflow `.github/workflows/PRtests.yml` that detects which parts of the codebase have changed in a pull request and conditionally triggers only the relevant test workflows for those components (API, CRON, IA, FRONT, NOTIF, WORKER).

These changes make the CI process more targeted and efficient by running only the necessary tests for each pull request.