### PR TITLE
tests: Add Sonar summary action and add unit tests for CRON/NOTIF/WORKER

### DIFF
--- a/.github/actions/sonarqube-summary/action.yml
+++ b/.github/actions/sonarqube-summary/action.yml
@@ -1,0 +1,28 @@
+name: 'SonarQube Summary'
+description: 'Poll a SonarQube background task and publish issues/coverage/duplication metrics to the GitHub Actions job summary'
+
+inputs:
+  project-key:
+    description: 'SonarQube project key that was analyzed'
+    required: true
+  sonar-host-url:
+    description: 'SonarQube server URL'
+    required: true
+  sonar-token:
+    description: 'SonarQube auth token'
+    required: true
+  title:
+    description: 'Title shown in the job summary section'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - shell: bash
+      env:
+        SONAR_HOST_URL: ${{ inputs.sonar-host-url }}
+        SONAR_TOKEN: ${{ inputs.sonar-token }}
+        PROJECT_KEY: ${{ inputs.project-key }}
+        SUMMARY_TITLE: ${{ inputs.title }}
+      run: bash "${{ github.action_path }}/summary.sh"

--- a/.github/actions/sonarqube-summary/summary.sh
+++ b/.github/actions/sonarqube-summary/summary.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Required env: SONAR_HOST_URL, SONAR_TOKEN, PROJECT_KEY. Optional: SUMMARY_TITLE.
+TITLE="${SUMMARY_TITLE:-$PROJECT_KEY}"
+
+# report-task.txt is written by the scanner (location varies between the CLI
+# and .NET scanners), so just look for it anywhere in the workspace.
+REPORT_TASK_FILE=$(find "${GITHUB_WORKSPACE:-.}" -name 'report-task.txt' -print -quit 2>/dev/null)
+
+if [ -z "$REPORT_TASK_FILE" ]; then
+  echo "::warning::[$TITLE] report-task.txt not found, skipping SonarQube summary"
+  exit 0
+fi
+
+CE_TASK_ID=$(grep '^ceTaskId=' "$REPORT_TASK_FILE" | cut -d'=' -f2-)
+if [ -z "$CE_TASK_ID" ]; then
+  echo "::warning::[$TITLE] ceTaskId not found in report-task.txt"
+  exit 0
+fi
+
+STATUS="PENDING"
+ANALYSIS_ID=""
+for _ in $(seq 1 30); do
+  RESPONSE=$(curl -sf -u "$SONAR_TOKEN:" "$SONAR_HOST_URL/api/ce/task?id=$CE_TASK_ID") || {
+    echo "::warning::[$TITLE] Failed to call the SonarQube API (ce/task)"
+    exit 0
+  }
+  STATUS=$(echo "$RESPONSE" | jq -r '.task.status')
+  if [ "$STATUS" = "SUCCESS" ] || [ "$STATUS" = "FAILED" ] || [ "$STATUS" = "CANCELED" ]; then
+    ANALYSIS_ID=$(echo "$RESPONSE" | jq -r '.task.analysisId // empty')
+    break
+  fi
+  sleep 5
+done
+
+if [ "$STATUS" != "SUCCESS" ]; then
+  echo "::warning::[$TITLE] SonarQube analysis did not succeed (status=$STATUS)"
+  exit 0
+fi
+
+METRIC_KEYS="bugs,vulnerabilities,code_smells,security_hotspots,coverage,duplicated_lines_density,ncloc"
+MEASURES=$(curl -sf -u "$SONAR_TOKEN:" "$SONAR_HOST_URL/api/measures/component?component=$(printf '%s' "$PROJECT_KEY" | jq -sRr @uri)&metricKeys=$METRIC_KEYS") || {
+  echo "::warning::[$TITLE] Failed to call the SonarQube API (measures/component)"
+  exit 0
+}
+
+metric() {
+  echo "$MEASURES" | jq -r --arg key "$1" '(.component.measures[]? | select(.metric == $key) | .value) // "N/A"'
+}
+
+percent() {
+  local value="$1"
+  if [ "$value" = "N/A" ]; then echo "N/A"; else echo "${value}%"; fi
+}
+
+BUGS=$(metric bugs)
+VULNERABILITIES=$(metric vulnerabilities)
+CODE_SMELLS=$(metric code_smells)
+HOTSPOTS=$(metric security_hotspots)
+COVERAGE=$(percent "$(metric coverage)")
+DUPLICATION=$(percent "$(metric duplicated_lines_density)")
+NCLOC=$(metric ncloc)
+
+QG_ICON="⚪"
+QG_STATUS="N/A"
+if [ -n "$ANALYSIS_ID" ]; then
+  QG=$(curl -sf -u "$SONAR_TOKEN:" "$SONAR_HOST_URL/api/qualitygates/project_status?analysisId=$ANALYSIS_ID") && {
+    QG_STATUS=$(echo "$QG" | jq -r '.projectStatus.status // "N/A"')
+    if [ "$QG_STATUS" = "OK" ]; then
+      QG_ICON="✅"
+    elif [ "$QG_STATUS" = "ERROR" ]; then
+      QG_ICON="❌"
+    fi
+  }
+fi
+
+{
+  echo "### SonarQube - $TITLE"
+  echo ""
+  echo "Quality Gate: $QG_ICON **$QG_STATUS** — [view dashboard]($SONAR_HOST_URL/dashboard?id=$PROJECT_KEY)"
+  echo ""
+  echo "| Bugs | Vulnerabilities | Code Smells | Security Hotspots | Coverage | Duplication | Lines of Code |"
+  echo "|---|---|---|---|---|---|---|"
+  echo "| $BUGS | $VULNERABILITIES | $CODE_SMELLS | $HOTSPOTS | $COVERAGE | $DUPLICATION | $NCLOC |"
+  echo ""
+} >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/PRtestsAPI.yml
+++ b/.github/workflows/PRtestsAPI.yml
@@ -62,3 +62,11 @@ jobs:
       if: steps.sonarqube.outcome == 'failure'
       run: |
         echo "::warning::SonarQube scan failed - server may be unreachable"
+    - name: SonarQube Summary
+      if: steps.sonarqube.outcome == 'success'
+      uses: ./.github/actions/sonarqube-summary
+      with:
+        project-key: "PR-${{ steps.get-pr-id.outputs.pr_id }}-electrostore-api"
+        sonar-host-url: ${{ secrets.SONAR_HOST_URL }}
+        sonar-token: ${{ secrets.SONAR_TOKEN }}
+        title: API

--- a/.github/workflows/PRtestsCRON.yml
+++ b/.github/workflows/PRtestsCRON.yml
@@ -62,3 +62,11 @@ jobs:
       if: steps.sonarqube.outcome == 'failure'
       run: |
         echo "::warning::SonarQube scan failed - server may be unreachable"
+    - name: SonarQube Summary
+      if: steps.sonarqube.outcome == 'success'
+      uses: ./.github/actions/sonarqube-summary
+      with:
+        project-key: "PR-${{ steps.get-pr-id.outputs.pr_id }}-electrostore-cron"
+        sonar-host-url: ${{ secrets.SONAR_HOST_URL }}
+        sonar-token: ${{ secrets.SONAR_TOKEN }}
+        title: CRON

--- a/.github/workflows/PRtestsFRONT.yml
+++ b/.github/workflows/PRtestsFRONT.yml
@@ -69,3 +69,11 @@ jobs:
       if: steps.sonarqube.outcome == 'failure'
       run: |
         echo "::warning::SonarQube scan failed - server may be unreachable"
+    - name: SonarQube Summary
+      if: steps.sonarqube.outcome == 'success'
+      uses: ./.github/actions/sonarqube-summary
+      with:
+        project-key: "PR-${{ steps.get-pr-id.outputs.pr_id }}-electrostore-front"
+        sonar-host-url: ${{ secrets.SONAR_HOST_URL }}
+        sonar-token: ${{ secrets.SONAR_TOKEN }}
+        title: FRONT

--- a/.github/workflows/PRtestsIA.yml
+++ b/.github/workflows/PRtestsIA.yml
@@ -62,3 +62,11 @@ jobs:
       if: steps.sonarqube.outcome == 'failure'
       run: |
         echo "::warning::SonarQube scan failed - server may be unreachable"
+    - name: SonarQube Summary
+      if: steps.sonarqube.outcome == 'success'
+      uses: ./.github/actions/sonarqube-summary
+      with:
+        project-key: "PR-${{ steps.get-pr-id.outputs.pr_id }}-electrostore-ia"
+        sonar-host-url: ${{ secrets.SONAR_HOST_URL }}
+        sonar-token: ${{ secrets.SONAR_TOKEN }}
+        title: IA

--- a/.github/workflows/PRtestsNOTIF.yml
+++ b/.github/workflows/PRtestsNOTIF.yml
@@ -62,3 +62,11 @@ jobs:
       if: steps.sonarqube.outcome == 'failure'
       run: |
         echo "::warning::SonarQube scan failed - server may be unreachable"
+    - name: SonarQube Summary
+      if: steps.sonarqube.outcome == 'success'
+      uses: ./.github/actions/sonarqube-summary
+      with:
+        project-key: "PR-${{ steps.get-pr-id.outputs.pr_id }}-electrostore-notif"
+        sonar-host-url: ${{ secrets.SONAR_HOST_URL }}
+        sonar-token: ${{ secrets.SONAR_TOKEN }}
+        title: NOTIF

--- a/.github/workflows/PRtestsWORKER.yml
+++ b/.github/workflows/PRtestsWORKER.yml
@@ -62,3 +62,11 @@ jobs:
       if: steps.sonarqube.outcome == 'failure'
       run: |
         echo "::warning::SonarQube scan failed - server may be unreachable"
+    - name: SonarQube Summary
+      if: steps.sonarqube.outcome == 'success'
+      uses: ./.github/actions/sonarqube-summary
+      with:
+        project-key: "PR-${{ steps.get-pr-id.outputs.pr_id }}-electrostore-worker"
+        sonar-host-url: ${{ secrets.SONAR_HOST_URL }}
+        sonar-token: ${{ secrets.SONAR_TOKEN }}
+        title: WORKER

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,6 +82,14 @@ jobs:
       if: steps.sonarqube.outcome == 'failure'
       run: |
         echo "::warning::SonarQube scan failed - server may be unreachable"
+    - name: SonarQube Summary
+      if: steps.sonarqube.outcome == 'success'
+      uses: ./.github/actions/sonarqube-summary
+      with:
+        project-key: "${{ inputs.branch }}-${{ matrix.sonar_key }}"
+        sonar-host-url: ${{ secrets.SONAR_HOST_URL }}
+        sonar-token: ${{ secrets.SONAR_TOKEN }}
+        title: ${{ matrix.service_name }}
 
   test-frontend:
     name: tests - FRONT
@@ -138,3 +146,11 @@ jobs:
       if: steps.sonarqube.outcome == 'failure'
       run: |
         echo "::warning::SonarQube scan failed - server may be unreachable"
+    - name: SonarQube Summary
+      if: steps.sonarqube.outcome == 'success'
+      uses: ./.github/actions/sonarqube-summary
+      with:
+        project-key: "${{ inputs.branch }}-electrostore-front"
+        sonar-host-url: ${{ secrets.SONAR_HOST_URL }}
+        sonar-token: ${{ secrets.SONAR_TOKEN }}
+        title: FRONT

--- a/electrostoreCRON/Kafka/Consumers/KafkaCronJobEventsConsumer.cs
+++ b/electrostoreCRON/Kafka/Consumers/KafkaCronJobEventsConsumer.cs
@@ -101,7 +101,15 @@ public class KafkaCronJobEventsConsumer : BackgroundService
             consumer.Commit(result);
             return;
         }
-        var dispatched = await HandleEventAsync(msg, ct);
+        var dispatched = false;
+        try
+        {
+            dispatched = await HandleEventAsync(msg, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error dispatching message for offset {Offset}", result.Offset);
+        }
         if (dispatched)
         {
             consumer.Commit(result);

--- a/electrostoreNOTIF/Kafka/Consumers/KafkaNotifConsumer.cs
+++ b/electrostoreNOTIF/Kafka/Consumers/KafkaNotifConsumer.cs
@@ -125,7 +125,15 @@ public class KafkaNotifConsumer : BackgroundService
             consumer.Commit(result);
             return;
         }
-        var dispatched = await DispatchAsync(msg, ct);
+        var dispatched = false;
+        try
+        {
+            dispatched = await DispatchAsync(msg, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error dispatching message for offset {Offset}", result.Offset);
+        }
         if (dispatched)
         {
             consumer.Commit(result);

--- a/electrostoreWORKER/Kafka/Consumers/KafkaIaStatusConsumer.cs
+++ b/electrostoreWORKER/Kafka/Consumers/KafkaIaStatusConsumer.cs
@@ -114,7 +114,15 @@ public class KafkaIaStatusConsumer : BackgroundService
             consumer.Commit(result);
             return;
         }
-        var dispatched = await DispatchAsync(msg, ct);
+        var dispatched = false;
+        try
+        {
+            dispatched = await DispatchAsync(msg, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error dispatching message for offset {Offset}", result.Offset);
+        }
         if (dispatched)
         {
             consumer.Commit(result);

--- a/electrostoreWORKER/Kafka/Consumers/KafkaMqttUserConsumer.cs
+++ b/electrostoreWORKER/Kafka/Consumers/KafkaMqttUserConsumer.cs
@@ -118,7 +118,15 @@ public class KafkaMqttUserConsumer : BackgroundService
             consumer.Commit(result);
             return;
         }
-        var dispatched = await DispatchAsync(msg, ct);
+        var dispatched = false;
+        try
+        {
+            dispatched = await DispatchAsync(msg, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error dispatching message for offset {Offset}", result.Offset);
+        }
         if (dispatched)
         {
             consumer.Commit(result);

--- a/electrostoreWORKER/Kafka/Consumers/KafkaTrackingResultConsumer.cs
+++ b/electrostoreWORKER/Kafka/Consumers/KafkaTrackingResultConsumer.cs
@@ -117,7 +117,15 @@ public class KafkaTrackingResultConsumer : BackgroundService
             consumer.Commit(result);
             return;
         }
-        var dispatched = await DispatchAsync(msg, ct);
+        var dispatched = false;
+        try
+        {
+            dispatched = await DispatchAsync(msg, ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error dispatching message for offset {Offset}", result.Offset);
+        }
         if (dispatched)
         {
             consumer.Commit(result);

--- a/tests/electrostoreCRON/Extensions/VaultConfigurationExtensionsTests.cs
+++ b/tests/electrostoreCRON/Extensions/VaultConfigurationExtensionsTests.cs
@@ -142,4 +142,33 @@ public class VaultConfigurationExtensionsTests
         // Assert
         Assert.Equal("plain-value", result["SomeSetting"]);
     }
+
+    [Fact]
+    public void AddVaultConfiguration_ShouldThrowInvalidOperationException_WhenSecretRetrievalFails()
+    {
+        // A config value references a vault secret ("{{vault:...}}"), which drives execution into
+        // the placeholder-substitution loop and the actual Vault HTTP call. Port 1 has nobody
+        // listening, so the connection is refused immediately (no DNS/timeout delay), letting
+        // GetVaultSecret's catch-and-wrap branch be exercised deterministically and fast.
+        // Note: the value must live under a nested key (e.g. "App:ApiKey") - SearchInConfigBranch
+        // only inspects the *children* of each top-level section, so a flat top-level key is
+        // never checked for a vault placeholder.
+        // Arrange
+        var builder = BuildConfigBuilder(new Dictionary<string, string?>
+        {
+            ["Vault:Enable"] = "true",
+            ["Vault:Addr"] = "http://127.0.0.1:1",
+            ["Vault:Token"] = "token",
+            ["Vault:Path"] = "secret/path",
+            ["Vault:MountPoint"] = "secret",
+            ["App:ApiKey"] = "prefix-{{vault:api-key}}-suffix"
+        });
+
+        // Act
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.AddVaultConfiguration());
+
+        // Assert
+        Assert.Contains("Failed to retrieve secret from Vault", exception.Message);
+        Assert.Contains("api-key", exception.Message);
+    }
 }

--- a/tests/electrostoreCRON/Kafka/Consumers/KafkaCronJobEventsConsumerTests.cs
+++ b/tests/electrostoreCRON/Kafka/Consumers/KafkaCronJobEventsConsumerTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Confluent.Kafka;
 using ElectrostoreCRON.Kafka.Consumers;
 using ElectrostoreCRON.Kafka.Messages;
 using Microsoft.Extensions.Configuration;
@@ -32,6 +33,37 @@ public class KafkaCronJobEventsConsumerTests
         var method = typeof(KafkaCronJobEventsConsumer).GetMethod("HandleEventAsync", BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("HandleEventAsync method not found");
         return (Task<bool>)method.Invoke(consumer, new object?[] { evt, ct })!;
+    }
+
+    private static ConsumeResult<string, string> CreateConsumeResult(string? value, bool isPartitionEOF = false, long offset = 1)
+    {
+        return new ConsumeResult<string, string>
+        {
+            Message = value is null ? null : new Message<string, string> { Value = value },
+            IsPartitionEOF = isPartitionEOF,
+            Offset = offset
+        };
+    }
+
+    private static Task<ConsumeResult<string, string>?> ConsumeMessageAsync(KafkaCronJobEventsConsumer consumer, IConsumer<string, string> kafkaConsumer, CancellationToken ct = default)
+    {
+        var method = typeof(KafkaCronJobEventsConsumer).GetMethod("ConsumeMessageAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ConsumeMessageAsync method not found");
+        return (Task<ConsumeResult<string, string>?>)method.Invoke(consumer, new object[] { kafkaConsumer, ct })!;
+    }
+
+    private static Task ProcessMessageAsync(KafkaCronJobEventsConsumer consumer, IConsumer<string, string> kafkaConsumer, ConsumeResult<string, string> result, CancellationToken ct = default)
+    {
+        var method = typeof(KafkaCronJobEventsConsumer).GetMethod("ProcessMessageAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ProcessMessageAsync method not found");
+        return (Task)method.Invoke(consumer, new object[] { kafkaConsumer, result, ct })!;
+    }
+
+    private static CronJobEvent? DeserializeMessage(KafkaCronJobEventsConsumer consumer, ConsumeResult<string, string> result)
+    {
+        var method = typeof(KafkaCronJobEventsConsumer).GetMethod("DeserializeMessage", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("DeserializeMessage method not found");
+        return (CronJobEvent?)method.Invoke(consumer, new object[] { result });
     }
 
     [Fact]
@@ -189,5 +221,172 @@ public class KafkaCronJobEventsConsumerTests
         Assert.Null(exception);
         _scheduler.Verify(s => s.ScheduleJob(It.IsAny<IJobDetail>(), It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()), Times.Never);
         _scheduler.Verify(s => s.DeleteJob(It.IsAny<JobKey>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ---- DeserializeMessage ----
+
+    [Fact]
+    public void DeserializeMessage_ShouldReturnMessage_WhenJsonIsValid()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var result = CreateConsumeResult("""{"action":"deleted","data":{"id_cronjob":9}}""");
+
+        // Act
+        var msg = DeserializeMessage(consumer, result);
+
+        // Assert
+        Assert.NotNull(msg);
+        Assert.Equal("deleted", msg!.action);
+    }
+
+    [Fact]
+    public void DeserializeMessage_ShouldReturnNull_WhenJsonIsInvalid()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var result = CreateConsumeResult("{not-json");
+
+        // Act
+        var msg = DeserializeMessage(consumer, result);
+
+        // Assert
+        Assert.Null(msg);
+    }
+
+    // ---- ConsumeMessageAsync ----
+
+    [Fact]
+    public async Task ConsumeMessageAsync_ShouldReturnResult_WhenConsumeSucceeds()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var expected = CreateConsumeResult("""{"action":"deleted","data":{"id_cronjob":9}}""");
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        kafkaConsumer.Setup(c => c.Consume(It.IsAny<CancellationToken>())).Returns(expected);
+
+        // Act
+        var result = await ConsumeMessageAsync(consumer, kafkaConsumer.Object);
+
+        // Assert
+        Assert.Same(expected, result);
+    }
+
+    [Fact]
+    public async Task ConsumeMessageAsync_ShouldReturnNull_WhenOperationIsCancelled()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        kafkaConsumer.Setup(c => c.Consume(It.IsAny<CancellationToken>())).Throws<OperationCanceledException>();
+
+        // Act
+        var result = await ConsumeMessageAsync(consumer, kafkaConsumer.Object);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ConsumeMessageAsync_ShouldReturnNull_WhenConsumeExceptionIsThrown()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        kafkaConsumer
+            .Setup(c => c.Consume(It.IsAny<CancellationToken>()))
+            .Throws(new ConsumeException(new ConsumeResult<byte[], byte[]>(), new Error(ErrorCode.UnknownTopicOrPart)));
+
+        // Act
+        var result = await ConsumeMessageAsync(consumer, kafkaConsumer.Object);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    // ---- ProcessMessageAsync ----
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldDoNothing_WhenResultIsPartitionEOF()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult(null, isPartitionEOF: true);
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        kafkaConsumer.Verify(c => c.Commit(It.IsAny<ConsumeResult<string, string>>()), Times.Never);
+        _schedulerFactory.Verify(f => f.GetScheduler(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldDoNothing_WhenMessageValueIsNull()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult(null);
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        kafkaConsumer.Verify(c => c.Commit(It.IsAny<ConsumeResult<string, string>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldCommitWithoutDispatching_WhenJsonIsInvalid()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult("{not-json");
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        kafkaConsumer.Verify(c => c.Commit(result), Times.Once);
+        _schedulerFactory.Verify(f => f.GetScheduler(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldDispatchAndCommit_WhenMessageIsValid()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult("""{"action":"deleted","data":{"id_cronjob":9}}""");
+        _scheduler.Setup(s => s.CheckExists(It.IsAny<JobKey>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+        _scheduler.Setup(s => s.DeleteJob(It.IsAny<JobKey>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        _scheduler.Verify(s => s.DeleteJob(It.Is<JobKey>(k => k.Name == "job-9"), It.IsAny<CancellationToken>()), Times.Once);
+        kafkaConsumer.Verify(c => c.Commit(result), Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldNotCommitOrThrow_WhenDispatchThrows()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult("""{"action":"deleted","data":{"id_cronjob":9}}""");
+        _scheduler
+            .Setup(s => s.CheckExists(It.IsAny<JobKey>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("scheduler down"));
+
+        // Act
+        var exception = await Record.ExceptionAsync(() => ProcessMessageAsync(consumer, kafkaConsumer.Object, result));
+
+        // Assert
+        Assert.Null(exception);
+        kafkaConsumer.Verify(c => c.Commit(It.IsAny<ConsumeResult<string, string>>()), Times.Never);
     }
 }

--- a/tests/electrostoreCRON/Kafka/Producer/KafkaProducerServiceTests.cs
+++ b/tests/electrostoreCRON/Kafka/Producer/KafkaProducerServiceTests.cs
@@ -1,0 +1,57 @@
+using ElectrostoreCRON.Kafka.Producer;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace ElectrostoreCRON.Tests.Kafka.Producer;
+
+public class KafkaProducerServiceTests
+{
+    // The constructor builds a real Confluent.Kafka IProducer (not injected/mockable), and
+    // PublishAsync/ProduceAsync would either block for the full librdkafka message-timeout
+    // (minutes) or behave non-deterministically without a reachable broker, so only the
+    // construction and disposal lifecycle - which don't require connectivity - are unit-tested
+    // here.
+    private static KafkaProducerService CreateService(Dictionary<string, string?>? values = null)
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(values ?? []).Build();
+        return new KafkaProducerService(configuration, new Mock<ILogger<KafkaProducerService>>().Object);
+    }
+
+    [Fact]
+    public void Constructor_ShouldSucceed_WhenBootstrapServersIsMissing()
+    {
+        // Act
+        var exception = Record.Exception(() => CreateService());
+
+        // Assert
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Constructor_ShouldSucceed_WhenBootstrapServersIsProvided()
+    {
+        // Act
+        var exception = Record.Exception(() => CreateService(new Dictionary<string, string?>
+        {
+            ["Kafka:BootstrapServers"] = "127.0.0.1:1"
+        }));
+
+        // Assert
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Dispose_ShouldNotThrow_WhenNoMessageWasPublished()
+    {
+        // Arrange
+        var service = CreateService();
+
+        // Act
+        var exception = Record.Exception(service.Dispose);
+
+        // Assert
+        Assert.Null(exception);
+    }
+}

--- a/tests/electrostoreCRON/ProgramTests.cs
+++ b/tests/electrostoreCRON/ProgramTests.cs
@@ -1,0 +1,91 @@
+using System.Reflection;
+using ElectrostoreCRON.Grpc;
+using ElectrostoreCRON.Kafka.Consumers;
+using ElectrostoreCRON.Kafka.Producer;
+using ElectrostoreCRON.Services.ConfigCacheService;
+using ElectrostoreCRON.Services.CronSchedulerService;
+using ElectrostoreCRON.Services.Track17SyncService;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Quartz;
+using Xunit;
+
+namespace ElectrostoreCRON.Tests;
+
+public class ProgramTests
+{
+    // Program.Main() itself requires a real "config/appsettings.json" file and live infrastructure
+    // (Kafka, the API's gRPC endpoints, Quartz) once the hosted services start, so it isn't
+    // exercised directly. AddScopes is the private static method that owns the DI wiring and can
+    // be tested in isolation by inspecting the resulting IServiceCollection without building/
+    // starting the host.
+    private static void InvokeAddScopes(WebApplicationBuilder builder)
+    {
+        var method = typeof(Program).GetMethod("AddScopes", BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("AddScopes method not found");
+        method.Invoke(null, new object[] { builder });
+    }
+
+    [Fact]
+    public void AddScopes_ShouldRegisterAllServices_AsSingletons()
+    {
+        // Arrange
+        var builder = WebApplication.CreateBuilder();
+
+        // Act
+        InvokeAddScopes(builder);
+
+        // Assert
+        Assert.Contains(builder.Services, d => d.ServiceType == typeof(IKafkaProducerService) && d.ImplementationType == typeof(KafkaProducerService) && d.Lifetime == ServiceLifetime.Singleton);
+        Assert.Contains(builder.Services, d => d.ServiceType == typeof(ITrack17SyncService) && d.ImplementationType == typeof(Track17SyncService) && d.Lifetime == ServiceLifetime.Singleton);
+        Assert.Contains(builder.Services, d => d.ServiceType == typeof(ConfigCacheService) && d.Lifetime == ServiceLifetime.Singleton);
+        Assert.Contains(builder.Services, d => d.ServiceType == typeof(IConfigCacheService) && d.Lifetime == ServiceLifetime.Singleton);
+        Assert.Contains(builder.Services, d => d.ServiceType == typeof(ElectrostoreCronJob) && d.Lifetime == ServiceLifetime.Transient);
+    }
+
+    [Fact]
+    public void AddScopes_ShouldRegisterAllExpectedHostedServices()
+    {
+        // Arrange
+        var builder = WebApplication.CreateBuilder();
+
+        // Act
+        InvokeAddScopes(builder);
+
+        // Assert - ConfigCacheService (via factory) + CronSchedulerService + the Kafka cronjob-events consumer
+        var hostedServiceDescriptors = builder.Services.Where(d => d.ServiceType == typeof(IHostedService)).ToList();
+        Assert.Equal(3, hostedServiceDescriptors.Count);
+        Assert.Contains(hostedServiceDescriptors, d => d.ImplementationType == typeof(CronSchedulerService));
+        Assert.Contains(hostedServiceDescriptors, d => d.ImplementationType == typeof(KafkaCronJobEventsConsumer));
+    }
+
+    [Fact]
+    public void AddScopes_ShouldResolveConfigCacheServiceHostedServiceToSameSingletonInstance()
+    {
+        // The ConfigCacheService hosted-service registration uses a factory that must resolve to
+        // the very same singleton instance also exposed as IConfigCacheService, so the cache state
+        // observed by consumers matches the instance the host actually starts/stops.
+        // Arrange
+        var builder = WebApplication.CreateBuilder();
+        InvokeAddScopes(builder);
+        // The hosted services depend on Quartz's ISchedulerFactory and generated gRPC clients,
+        // which AddScopes doesn't register (Program.Main wires them separately via AddQuartz/
+        // AddGrpcClient) - supply mocks so that resolving IHostedService (which activates every
+        // registered hosted service) succeeds.
+        builder.Services.AddSingleton(new Mock<ISchedulerFactory>().Object);
+        builder.Services.AddSingleton(new Mock<ConfigGrpc.ConfigGrpcClient>().Object);
+        builder.Services.AddSingleton(new Mock<CronJobsGrpc.CronJobsGrpcClient>().Object);
+        using var provider = builder.Services.BuildServiceProvider();
+
+        // Act
+        var configCacheService = provider.GetRequiredService<ConfigCacheService>();
+        var configCacheInterface = provider.GetRequiredService<IConfigCacheService>();
+        var hostedConfigCacheService = provider.GetServices<IHostedService>().OfType<ConfigCacheService>().Single();
+
+        // Assert
+        Assert.Same(configCacheService, configCacheInterface);
+        Assert.Same(configCacheService, hostedConfigCacheService);
+    }
+}

--- a/tests/electrostoreCRON/Services/CronSchedulerServiceTests.cs
+++ b/tests/electrostoreCRON/Services/CronSchedulerServiceTests.cs
@@ -49,6 +49,13 @@ public class CronSchedulerServiceTests
         return (Task)method.Invoke(service, new object[] { scheduler, ct })!;
     }
 
+    private static Task InvokeExecuteAsync(CronSchedulerService service, CancellationToken ct)
+    {
+        var method = typeof(CronSchedulerService).GetMethod("ExecuteAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ExecuteAsync method not found");
+        return (Task)method.Invoke(service, new object[] { ct })!;
+    }
+
     [Fact]
     public async Task LoadAndScheduleJobsAsync_ShouldScheduleJob_WithNormalizedCronExpression()
     {
@@ -168,5 +175,33 @@ public class CronSchedulerServiceTests
         // Assert
         Assert.Null(exception);
         scheduler.Verify(s => s.ScheduleJob(It.IsAny<IJobDetail>(), It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldStartSchedulerAndLoadJobs_BeforeEnteringRefreshLoop()
+    {
+        // ExecuteAsync's refresh loop runs on a real wall-clock PeriodicTimer tied to
+        // CronRefreshIntervalMinutes, so it isn't awaited here. Passing an already-cancelled
+        // token lets scheduler startup and the initial job load run and be verified, then
+        // PeriodicTimer.WaitForNextTickAsync throws OperationCanceledException immediately
+        // instead of actually waiting - keeping this fast and deterministic.
+        // Arrange
+        var service = CreateService();
+        var scheduler = new Mock<IScheduler>();
+        _schedulerFactory.Setup(f => f.GetScheduler(It.IsAny<CancellationToken>())).ReturnsAsync(scheduler.Object);
+        var reply = new GetEnabledCronJobsReply();
+        _apiClient
+            .Setup(c => c.GetEnabledCronJobsAsync(It.IsAny<GetEnabledCronJobsRequest>(), It.IsAny<Metadata>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .Returns(CreateAsyncUnaryCall(reply));
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // Act
+        var exception = await Record.ExceptionAsync(() => InvokeExecuteAsync(service, cts.Token));
+
+        // Assert
+        Assert.IsAssignableFrom<OperationCanceledException>(exception);
+        scheduler.Verify(s => s.Start(It.IsAny<CancellationToken>()), Times.Once);
+        _apiClient.Verify(c => c.GetEnabledCronJobsAsync(It.IsAny<GetEnabledCronJobsRequest>(), It.IsAny<Metadata>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/tests/electrostoreCRON/Services/ElectrostoreCronJobTests.cs
+++ b/tests/electrostoreCRON/Services/ElectrostoreCronJobTests.cs
@@ -79,6 +79,27 @@ public class ElectrostoreCronJobTests
     }
 
     [Fact]
+    public async Task Execute_ShouldNotCallTrack17Sync_AndShouldStillUpdateLastRun_WhenActionKeyIsAbsentFromJobDataMap()
+    {
+        // Arrange - Enum.TryParse fails on a null/missing value, exercising the "action = -1"
+        // fallback branch rather than an unhandled-but-valid CronJobAction value.
+        var job = CreateJob();
+        var context = CreateContext(9, action: null);
+        _apiClient
+            .Setup(c => c.UpdateCronJobRunAsync(It.IsAny<UpdateCronJobRunRequest>(), It.IsAny<Metadata>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .Returns(CreateAsyncUnaryCall(new UpdateCronJobRunReply { Success = true }));
+
+        // Act
+        await job.Execute(context.Object);
+
+        // Assert
+        _track17Sync.Verify(s => s.SyncAllAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _apiClient.Verify(c => c.UpdateCronJobRunAsync(
+            It.Is<UpdateCronJobRunRequest>(r => r.IdCronjob == 9),
+            It.IsAny<Metadata>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task Execute_ShouldNotCallTrack17Sync_AndShouldStillUpdateLastRun_WhenActionIsUnknown()
     {
         // Arrange

--- a/tests/electrostoreCRON/Services/Track17SyncServiceTests.cs
+++ b/tests/electrostoreCRON/Services/Track17SyncServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Reflection;
 using System.Text.Json;
+using Confluent.Kafka;
 using ElectrostoreCRON.Kafka.Messages;
 using ElectrostoreCRON.Kafka.Producer;
 using ElectrostoreCRON.Services.Track17SyncService;
@@ -73,6 +74,30 @@ public class Track17SyncServiceTests
         return (object[])method.Invoke(null, new object[] { action, messages })!;
     }
 
+    private static ConsumeResult<string, string> CreateConsumeResult(string? value, bool isPartitionEOF = false, long offset = 1)
+    {
+        return new ConsumeResult<string, string>
+        {
+            Message = value is null ? null : new Message<string, string> { Value = value },
+            IsPartitionEOF = isPartitionEOF,
+            Offset = offset
+        };
+    }
+
+    private static Task<ConsumeResult<string, string>?> ConsumeMessageAsync(Track17SyncService service, IConsumer<string, string> kafkaConsumer, CancellationToken ct = default)
+    {
+        var method = typeof(Track17SyncService).GetMethod("ConsumeMessageAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ConsumeMessageAsync method not found");
+        return (Task<ConsumeResult<string, string>?>)method.Invoke(service, new object[] { kafkaConsumer, ct })!;
+    }
+
+    private static TrackingActionMessage? DeserializeMessage(Track17SyncService service, ConsumeResult<string, string> result)
+    {
+        var method = typeof(Track17SyncService).GetMethod("DeserializeMessage", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("DeserializeMessage method not found");
+        return (TrackingActionMessage?)method.Invoke(service, new object[] { result });
+    }
+
     // ---- SyncAllAsync ----
 
     [Fact]
@@ -87,6 +112,87 @@ public class Track17SyncServiceTests
         // Assert
         _httpClientFactory.Verify(f => f.CreateClient(It.IsAny<string>()), Times.Never);
         _kafka.Verify(k => k.PublishAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ---- DeserializeMessage ----
+
+    [Fact]
+    public void DeserializeMessage_ShouldReturnMessage_WhenJsonIsValid()
+    {
+        // Arrange
+        var service = CreateService();
+        var result = CreateConsumeResult("""{"tracking_number":"TN1","carrier":100}""");
+
+        // Act
+        var msg = DeserializeMessage(service, result);
+
+        // Assert
+        Assert.NotNull(msg);
+        Assert.Equal("TN1", msg!.tracking_number);
+    }
+
+    [Fact]
+    public void DeserializeMessage_ShouldReturnNull_WhenJsonIsInvalid()
+    {
+        // Arrange
+        var service = CreateService();
+        var result = CreateConsumeResult("{not-json");
+
+        // Act
+        var msg = DeserializeMessage(service, result);
+
+        // Assert
+        Assert.Null(msg);
+    }
+
+    // ---- ConsumeMessageAsync ----
+
+    [Fact]
+    public async Task ConsumeMessageAsync_ShouldReturnResult_WhenConsumeSucceeds()
+    {
+        // Arrange
+        var service = CreateService();
+        var expected = CreateConsumeResult("""{"tracking_number":"TN1","carrier":100}""");
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        kafkaConsumer.Setup(c => c.Consume(It.IsAny<TimeSpan>())).Returns(expected);
+
+        // Act
+        var result = await ConsumeMessageAsync(service, kafkaConsumer.Object);
+
+        // Assert
+        Assert.Same(expected, result);
+    }
+
+    [Fact]
+    public async Task ConsumeMessageAsync_ShouldReturnNull_WhenOperationIsCancelled()
+    {
+        // Arrange
+        var service = CreateService();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        kafkaConsumer.Setup(c => c.Consume(It.IsAny<TimeSpan>())).Throws<OperationCanceledException>();
+
+        // Act
+        var result = await ConsumeMessageAsync(service, kafkaConsumer.Object);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ConsumeMessageAsync_ShouldReturnNull_WhenConsumeExceptionIsThrown()
+    {
+        // Arrange
+        var service = CreateService();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        kafkaConsumer
+            .Setup(c => c.Consume(It.IsAny<TimeSpan>()))
+            .Throws(new ConsumeException(new ConsumeResult<byte[], byte[]>(), new Error(ErrorCode.UnknownTopicOrPart)));
+
+        // Act
+        var result = await ConsumeMessageAsync(service, kafkaConsumer.Object);
+
+        // Assert
+        Assert.Null(result);
     }
 
     // ---- BuildRequestItems ----
@@ -279,5 +385,31 @@ public class Track17SyncServiceTests
         // Assert
         var result = Assert.Single(results);
         Assert.False(result.success);
+    }
+
+    [Fact(Timeout = 15000)]
+    public async Task SyncAllAsync_ShouldSkipEveryTopic_WhenKafkaBrokerIsUnreachable()
+    {
+        // ConsumeBatch builds its own real Confluent.Kafka IConsumer internally (not
+        // injected/mockable), so this exercises the full SyncAllAsync -> SyncTopicAsync ->
+        // ConsumeBatch orchestration loop end-to-end against an unreachable broker (127.0.0.1:1,
+        // connection refused) rather than mocking pieces of it. A short ConsumeTimeoutMs keeps the
+        // 5-empty-poll bail-out bounded (~5 * 100ms per topic * 5 topics), so this stays fast and
+        // deterministic instead of depending on librdkafka's multi-minute default message timeout.
+        // Arrange
+        var service = CreateService(new Dictionary<string, string?>
+        {
+            ["Track17:ApiKey"] = "test-key",
+            ["Kafka:BootstrapServers"] = "127.0.0.1:1",
+            ["Track17:ConsumeTimeoutMs"] = "100"
+        });
+
+        // Act
+        var exception = await Record.ExceptionAsync(() => service.SyncAllAsync());
+
+        // Assert
+        Assert.Null(exception);
+        _httpClientFactory.Verify(f => f.CreateClient(It.IsAny<string>()), Times.Never);
+        _kafka.Verify(k => k.PublishAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/tests/electrostoreNOTIF/Extensions/VaultConfigurationExtensionsTests.cs
+++ b/tests/electrostoreNOTIF/Extensions/VaultConfigurationExtensionsTests.cs
@@ -142,4 +142,33 @@ public class VaultConfigurationExtensionsTests
         // Assert
         Assert.Equal("plain-value", result["SomeSetting"]);
     }
+
+    [Fact]
+    public void AddVaultConfiguration_ShouldThrowInvalidOperationException_WhenSecretRetrievalFails()
+    {
+        // A config value references a vault secret ("{{vault:...}}"), which drives execution into
+        // the placeholder-substitution loop and the actual Vault HTTP call. Port 1 has nobody
+        // listening, so the connection is refused immediately (no DNS/timeout delay), letting
+        // GetVaultSecret's catch-and-wrap branch be exercised deterministically and fast.
+        // Note: the value must live under a nested key (e.g. "App:ApiKey") - SearchInConfigBranch
+        // only inspects the *children* of each top-level section, so a flat top-level key is
+        // never checked for a vault placeholder.
+        // Arrange
+        var builder = BuildConfigBuilder(new Dictionary<string, string?>
+        {
+            ["Vault:Enable"] = "true",
+            ["Vault:Addr"] = "http://127.0.0.1:1",
+            ["Vault:Token"] = "token",
+            ["Vault:Path"] = "secret/path",
+            ["Vault:MountPoint"] = "secret",
+            ["App:ApiKey"] = "prefix-{{vault:api-key}}-suffix"
+        });
+
+        // Act
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.AddVaultConfiguration());
+
+        // Assert
+        Assert.Contains("Failed to retrieve secret from Vault", exception.Message);
+        Assert.Contains("api-key", exception.Message);
+    }
 }

--- a/tests/electrostoreNOTIF/Kafka/Consumers/KafkaNotifConsumerTests.cs
+++ b/tests/electrostoreNOTIF/Kafka/Consumers/KafkaNotifConsumerTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Confluent.Kafka;
 using ElectrostoreNOTIF.Grpc;
 using ElectrostoreNOTIF.Kafka.Consumers;
 using ElectrostoreNOTIF.Kafka.Messages;
@@ -10,6 +11,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
+using Metadata = Grpc.Core.Metadata;
 
 namespace ElectrostoreNOTIF.Tests.Kafka.Consumers;
 
@@ -58,6 +60,37 @@ public class KafkaNotifConsumerTests
         var method = typeof(KafkaNotifConsumer).GetMethod("DispatchAsync", BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("DispatchAsync method not found");
         return (Task)method.Invoke(consumer, new object[] { message, ct })!;
+    }
+
+    private static ConsumeResult<string, string> CreateConsumeResult(string? value, bool isPartitionEOF = false, long offset = 1)
+    {
+        return new ConsumeResult<string, string>
+        {
+            Message = value is null ? null : new Message<string, string> { Value = value },
+            IsPartitionEOF = isPartitionEOF,
+            Offset = offset
+        };
+    }
+
+    private static Task<ConsumeResult<string, string>?> ConsumeMessageAsync(KafkaNotifConsumer consumer, IConsumer<string, string> kafkaConsumer, CancellationToken ct = default)
+    {
+        var method = typeof(KafkaNotifConsumer).GetMethod("ConsumeMessageAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ConsumeMessageAsync method not found");
+        return (Task<ConsumeResult<string, string>?>)method.Invoke(consumer, new object[] { kafkaConsumer, ct })!;
+    }
+
+    private static Task ProcessMessageAsync(KafkaNotifConsumer consumer, IConsumer<string, string> kafkaConsumer, ConsumeResult<string, string> result, CancellationToken ct = default)
+    {
+        var method = typeof(KafkaNotifConsumer).GetMethod("ProcessMessageAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ProcessMessageAsync method not found");
+        return (Task)method.Invoke(consumer, new object[] { kafkaConsumer, result, ct })!;
+    }
+
+    private static NotificationMessage? DeserializeMessage(KafkaNotifConsumer consumer, ConsumeResult<string, string> result)
+    {
+        var method = typeof(KafkaNotifConsumer).GetMethod("DeserializeMessage", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("DeserializeMessage method not found");
+        return (NotificationMessage?)method.Invoke(consumer, new object[] { result });
     }
 
     [Fact]
@@ -300,5 +333,170 @@ public class KafkaNotifConsumerTests
         Assert.Null(exception);
         _emailService.Verify(e => e.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
         _webPushService.Verify(w => w.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>?>()), Times.Never);
+    }
+
+    // ---- DeserializeMessage ----
+
+    [Fact]
+    public void DeserializeMessage_ShouldReturnMessage_WhenJsonIsValid()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var result = CreateConsumeResult("""{"types":["email"],"recipientEmail":"user@example.com"}""");
+
+        // Act
+        var msg = DeserializeMessage(consumer, result);
+
+        // Assert
+        Assert.NotNull(msg);
+        Assert.Equal("user@example.com", msg!.RecipientEmail);
+    }
+
+    [Fact]
+    public void DeserializeMessage_ShouldReturnNull_WhenJsonIsInvalid()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var result = CreateConsumeResult("{not-json");
+
+        // Act
+        var msg = DeserializeMessage(consumer, result);
+
+        // Assert
+        Assert.Null(msg);
+    }
+
+    // ---- ConsumeMessageAsync ----
+
+    [Fact]
+    public async Task ConsumeMessageAsync_ShouldReturnResult_WhenConsumeSucceeds()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var expected = CreateConsumeResult("""{"types":["email"],"recipientEmail":"user@example.com"}""");
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        kafkaConsumer.Setup(c => c.Consume(It.IsAny<CancellationToken>())).Returns(expected);
+
+        // Act
+        var result = await ConsumeMessageAsync(consumer, kafkaConsumer.Object);
+
+        // Assert
+        Assert.Same(expected, result);
+    }
+
+    [Fact]
+    public async Task ConsumeMessageAsync_ShouldReturnNull_WhenOperationIsCancelled()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        kafkaConsumer.Setup(c => c.Consume(It.IsAny<CancellationToken>())).Throws<OperationCanceledException>();
+
+        // Act
+        var result = await ConsumeMessageAsync(consumer, kafkaConsumer.Object);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ConsumeMessageAsync_ShouldReturnNull_WhenConsumeExceptionIsThrown()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        kafkaConsumer
+            .Setup(c => c.Consume(It.IsAny<CancellationToken>()))
+            .Throws(new ConsumeException(new ConsumeResult<byte[], byte[]>(), new Error(ErrorCode.UnknownTopicOrPart)));
+
+        // Act
+        var result = await ConsumeMessageAsync(consumer, kafkaConsumer.Object);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    // ---- ProcessMessageAsync ----
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldDoNothing_WhenResultIsPartitionEOF()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult(null, isPartitionEOF: true);
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        kafkaConsumer.Verify(c => c.Commit(It.IsAny<ConsumeResult<string, string>>()), Times.Never);
+        _emailService.Verify(e => e.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldDoNothing_WhenMessageValueIsNull()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult(null);
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        kafkaConsumer.Verify(c => c.Commit(It.IsAny<ConsumeResult<string, string>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldCommitWithoutDispatching_WhenJsonIsInvalid()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult("{not-json");
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        kafkaConsumer.Verify(c => c.Commit(result), Times.Once);
+        _emailService.Verify(e => e.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldDispatchAndCommit_WhenMessageIsValid()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult("""{"types":["email"],"recipientEmail":"user@example.com","subject":"S","body":"B"}""");
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        _emailService.Verify(e => e.SendAsync("user@example.com", "S", "B"), Times.Once);
+        kafkaConsumer.Verify(c => c.Commit(result), Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldNotCommitOrThrow_WhenDispatchThrows()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult("""{"types":["email"],"recipientEmail":"user@example.com","subject":"S","body":"B"}""");
+        _emailService
+            .Setup(e => e.SendAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .ThrowsAsync(new InvalidOperationException("smtp down"));
+
+        // Act
+        var exception = await Record.ExceptionAsync(() => ProcessMessageAsync(consumer, kafkaConsumer.Object, result));
+
+        // Assert
+        Assert.Null(exception);
+        kafkaConsumer.Verify(c => c.Commit(It.IsAny<ConsumeResult<string, string>>()), Times.Never);
     }
 }

--- a/tests/electrostoreNOTIF/ProgramTests.cs
+++ b/tests/electrostoreNOTIF/ProgramTests.cs
@@ -1,0 +1,98 @@
+using System.Reflection;
+using ElectrostoreNOTIF.Grpc;
+using ElectrostoreNOTIF.Kafka.Consumers;
+using ElectrostoreNOTIF.Services.ConfigCacheService;
+using ElectrostoreNOTIF.Services.EmailSenderService;
+using ElectrostoreNOTIF.Services.NotificationTemplateService;
+using ElectrostoreNOTIF.Services.WebPushService;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Xunit;
+
+namespace ElectrostoreNOTIF.Tests;
+
+public class ProgramTests
+{
+    // Program.Main() itself requires a real "config/appsettings.json" file and live infrastructure
+    // (Kafka, the API's gRPC endpoints) once the hosted services start, so it isn't exercised
+    // directly. AddScopes is the private static method that owns the DI wiring and can be tested
+    // in isolation by inspecting the resulting IServiceCollection without building/starting the host.
+    private static void InvokeAddScopes(WebApplicationBuilder builder)
+    {
+        var method = typeof(Program).GetMethod("AddScopes", BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("AddScopes method not found");
+        method.Invoke(null, new object[] { builder });
+    }
+
+    private static WebApplicationBuilder CreateBuilderWithVapidConfig()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["VAPID:PublicKey"] = "public-key",
+            ["VAPID:PrivateKey"] = "private-key"
+        });
+        return builder;
+    }
+
+    [Fact]
+    public void AddScopes_ShouldRegisterAllServices_AsSingletons()
+    {
+        // Arrange
+        var builder = WebApplication.CreateBuilder();
+
+        // Act
+        InvokeAddScopes(builder);
+
+        // Assert
+        Assert.Contains(builder.Services, d => d.ServiceType == typeof(IEmailSenderService) && d.ImplementationType == typeof(EmailSenderService) && d.Lifetime == ServiceLifetime.Singleton);
+        Assert.Contains(builder.Services, d => d.ServiceType == typeof(IWebPushService) && d.ImplementationType == typeof(WebPushService) && d.Lifetime == ServiceLifetime.Singleton);
+        Assert.Contains(builder.Services, d => d.ServiceType == typeof(INotificationTemplateService) && d.ImplementationType == typeof(NotificationTemplateService) && d.Lifetime == ServiceLifetime.Singleton);
+        Assert.Contains(builder.Services, d => d.ServiceType == typeof(ConfigCacheService) && d.Lifetime == ServiceLifetime.Singleton);
+        Assert.Contains(builder.Services, d => d.ServiceType == typeof(IConfigCacheService) && d.Lifetime == ServiceLifetime.Singleton);
+    }
+
+    [Fact]
+    public void AddScopes_ShouldRegisterAllExpectedHostedServices()
+    {
+        // Arrange
+        var builder = WebApplication.CreateBuilder();
+
+        // Act
+        InvokeAddScopes(builder);
+
+        // Assert - ConfigCacheService (via factory) + the Kafka notif consumer
+        var hostedServiceDescriptors = builder.Services.Where(d => d.ServiceType == typeof(IHostedService)).ToList();
+        Assert.Equal(2, hostedServiceDescriptors.Count);
+        Assert.Contains(hostedServiceDescriptors, d => d.ImplementationType == typeof(KafkaNotifConsumer));
+    }
+
+    [Fact]
+    public void AddScopes_ShouldResolveConfigCacheServiceHostedServiceToSameSingletonInstance()
+    {
+        // The ConfigCacheService hosted-service registration uses a factory that must resolve to
+        // the very same singleton instance also exposed as IConfigCacheService, so the cache state
+        // observed by consumers matches the instance the host actually starts/stops.
+        // Arrange
+        var builder = CreateBuilderWithVapidConfig();
+        InvokeAddScopes(builder);
+        // The hosted services depend on generated gRPC clients, which AddScopes doesn't register
+        // (Program.Main wires them separately via AddGrpcClient) - supply mocks so that resolving
+        // IHostedService (which activates every registered hosted service) succeeds.
+        builder.Services.AddSingleton(new Mock<ConfigGrpc.ConfigGrpcClient>().Object);
+        builder.Services.AddSingleton(new Mock<UsersGrpc.UsersGrpcClient>().Object);
+        using var provider = builder.Services.BuildServiceProvider();
+
+        // Act
+        var configCacheService = provider.GetRequiredService<ConfigCacheService>();
+        var configCacheInterface = provider.GetRequiredService<IConfigCacheService>();
+        var hostedConfigCacheService = provider.GetServices<IHostedService>().OfType<ConfigCacheService>().Single();
+
+        // Assert
+        Assert.Same(configCacheService, configCacheInterface);
+        Assert.Same(configCacheService, hostedConfigCacheService);
+    }
+}

--- a/tests/electrostoreNOTIF/Services/EmailSenderServiceTests.cs
+++ b/tests/electrostoreNOTIF/Services/EmailSenderServiceTests.cs
@@ -135,4 +135,72 @@ public class EmailSenderServiceTests
         // Assert
         Assert.Contains("SMTP:Password", exception.Message);
     }
+
+    // Once every required setting is present, SendAsync attempts a real SMTP connection
+    // (SmtpClient isn't injected/mockable). Port 1 has nobody listening, so the connection is
+    // refused immediately, exercising the generic catch-and-wrap branch deterministically and fast.
+
+    [Fact]
+    public async Task SendAsync_ShouldThrowInvalidOperationException_WhenSmtpServerIsUnreachable_OnStartTlsPort()
+    {
+        // Arrange - any port other than 465 selects SecureSocketOptions.StartTls
+        var service = CreateService(new Dictionary<string, string?>
+        {
+            ["SMTP:Enable"] = "true",
+            ["SMTP:From"] = "noreply@example.com",
+            ["SMTP:Host"] = "127.0.0.1",
+            ["SMTP:Port"] = "1",
+            ["SMTP:Username"] = "smtp-user",
+            ["SMTP:Password"] = "smtp-password"
+        });
+
+        // Act
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.SendAsync("user@example.com", "Subject", "Body"));
+
+        // Assert
+        Assert.Contains("Failed to send e-mail to user@example.com", exception.Message);
+    }
+
+    [Fact]
+    public async Task SendAsync_ShouldThrowInvalidOperationException_WhenSmtpServerIsUnreachable_OnSslOnConnectPort()
+    {
+        // Arrange - port 465 selects SecureSocketOptions.SslOnConnect
+        var service = CreateService(new Dictionary<string, string?>
+        {
+            ["SMTP:Enable"] = "true",
+            ["SMTP:From"] = "noreply@example.com",
+            ["SMTP:Host"] = "127.0.0.1",
+            ["SMTP:Port"] = "465",
+            ["SMTP:Username"] = "smtp-user",
+            ["SMTP:Password"] = "smtp-password"
+        });
+
+        // Act
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.SendAsync("user@example.com", "Subject", "Body"));
+
+        // Assert
+        Assert.Contains("Failed to send e-mail to user@example.com", exception.Message);
+    }
+
+    [Fact]
+    public async Task SendAsync_ShouldSkipAuthentication_WhenUsernameIsWhitespace()
+    {
+        // Arrange - a whitespace-only username passes the "?? throw" null-check but should skip
+        // the AuthenticateAsync call; the connection still fails since nothing listens on port 1.
+        var service = CreateService(new Dictionary<string, string?>
+        {
+            ["SMTP:Enable"] = "true",
+            ["SMTP:From"] = "noreply@example.com",
+            ["SMTP:Host"] = "127.0.0.1",
+            ["SMTP:Port"] = "1",
+            ["SMTP:Username"] = "   ",
+            ["SMTP:Password"] = "smtp-password"
+        });
+
+        // Act
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.SendAsync("user@example.com", "Subject", "Body"));
+
+        // Assert
+        Assert.Contains("Failed to send e-mail to user@example.com", exception.Message);
+    }
 }

--- a/tests/electrostoreNOTIF/Services/NotificationTemplateServiceTests.cs
+++ b/tests/electrostoreNOTIF/Services/NotificationTemplateServiceTests.cs
@@ -166,4 +166,192 @@ public class NotificationTemplateServiceTests
             File.Delete(templatePath);
         }
     }
+
+    private static string CreateTempTemplate(string language, string jsonContent, out string templateId)
+    {
+        templateId = $"test-{Guid.NewGuid():N}";
+        var templateDir = Path.Combine(AppContext.BaseDirectory, "Templates", language);
+        Directory.CreateDirectory(templateDir);
+        var templatePath = Path.Combine(templateDir, $"{templateId}.json");
+        File.WriteAllText(templatePath, jsonContent);
+        return templatePath;
+    }
+
+    [Fact]
+    public void RenderTemplate_ShouldReturnNull_WhenTemplateFileContainsMalformedJson()
+    {
+        // Arrange
+        var templatePath = CreateTempTemplate("en", "{not-json", out var templateId);
+        try
+        {
+            var service = CreateService(defaultLanguage: "en");
+
+            // Act
+            var result = service.RenderTemplate(templateId, null, "en");
+
+            // Assert
+            Assert.Null(result);
+        }
+        finally
+        {
+            File.Delete(templatePath);
+        }
+    }
+
+    [Fact]
+    public void RenderTemplate_ShouldReturnNull_WhenTemplateFileDeserializesToNull()
+    {
+        // Arrange
+        var templatePath = CreateTempTemplate("en", "null", out var templateId);
+        try
+        {
+            var service = CreateService(defaultLanguage: "en");
+
+            // Act
+            var result = service.RenderTemplate(templateId, null, "en");
+
+            // Assert
+            Assert.Null(result);
+        }
+        finally
+        {
+            File.Delete(templatePath);
+        }
+    }
+
+    [Fact]
+    public void RenderTemplate_ShouldReturnTextUnchanged_WhenValuesAreNull()
+    {
+        // Arrange
+        var templatePath = CreateTempTemplate("en", """{"subject":"Hi {{name}}","body":"Body {{name}}"}""", out var templateId);
+        try
+        {
+            var service = CreateService(defaultLanguage: "en");
+
+            // Act
+            var result = service.RenderTemplate(templateId, null, "en");
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Hi {{name}}", result!.Subject);
+            Assert.Equal("Body {{name}}", result.Body);
+        }
+        finally
+        {
+            File.Delete(templatePath);
+        }
+    }
+
+    [Fact]
+    public void RenderTemplate_ShouldLeavePlaceholderUnresolved_WhenKeyIsMissingFromValues()
+    {
+        // Arrange
+        var templatePath = CreateTempTemplate("en", """{"subject":"Hi {{name}}, {{unknown}}"}""", out var templateId);
+        try
+        {
+            var service = CreateService(defaultLanguage: "en");
+            var values = ParseValues("""{"name":"Alice"}""");
+
+            // Act
+            var result = service.RenderTemplate(templateId, values, "en");
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Hi Alice, {{unknown}}", result!.Subject);
+        }
+        finally
+        {
+            File.Delete(templatePath);
+        }
+    }
+
+    [Fact]
+    public void RenderTemplate_ShouldRenderEmptyString_WhenEachKeyIsMissingOrNotAnArray()
+    {
+        // Arrange
+        var templatePath = CreateTempTemplate("en", """{"body":"[missing:{{#each missing}}{{.}}{{/each}}][notArray:{{#each name}}{{.}}{{/each}}]"}""", out var templateId);
+        try
+        {
+            var service = CreateService(defaultLanguage: "en");
+            var values = ParseValues("""{"name":"not-an-array"}""");
+
+            // Act
+            var result = service.RenderTemplate(templateId, values, "en");
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("[missing:][notArray:]", result!.Body);
+        }
+        finally
+        {
+            File.Delete(templatePath);
+        }
+    }
+
+    [Fact]
+    public void RenderTemplate_ShouldRenderScalarAndObjectItems_AndFallBackToGlobalValues()
+    {
+        // Covers: scalar {{.}}, object {{.}} (renders empty), object property found,
+        // object property missing falling back to a global value, and a placeholder that
+        // resolves nowhere (kept literal). Also exercises number/bool/null scalar rendering.
+        // Arrange
+        var templatePath = CreateTempTemplate("en", """
+        {
+            "subject": "Count:{{count}} Active:{{active}} Nothing:{{nothing}}",
+            "body": "<ul>{{#each items}}<li>{{.}}|{{itemName}}|{{sharedNote}}|{{missingProp}}</li>{{/each}}</ul>"
+        }
+        """, out var templateId);
+        try
+        {
+            var service = CreateService(defaultLanguage: "en");
+            var values = ParseValues("""
+            {
+                "count": 5,
+                "active": true,
+                "nothing": null,
+                "sharedNote": "global-note",
+                "items": ["scalarItem", {"itemName": "ObjItem"}]
+            }
+            """);
+
+            // Act
+            var result = service.RenderTemplate(templateId, values, "en");
+
+            // Assert
+            Assert.NotNull(result);
+            Assert.Equal("Count:5 Active:true Nothing:", result!.Subject);
+            Assert.Contains("<li>scalarItem|{{itemName}}|global-note|{{missingProp}}</li>", result.Body);
+            Assert.Contains("<li>|ObjItem|global-note|{{missingProp}}</li>", result.Body);
+        }
+        finally
+        {
+            File.Delete(templatePath);
+        }
+    }
+
+    [Fact]
+    public void RenderTemplate_ShouldReturnSameResult_OnSecondCall_ServedFromCache()
+    {
+        // Arrange - the second RenderTemplate call for the same id/language is served from the
+        // in-memory cache instead of re-reading/parsing the file.
+        var templatePath = CreateTempTemplate("en", """{"subject":"Hi {{name}}"}""", out var templateId);
+        try
+        {
+            var service = CreateService(defaultLanguage: "en");
+            var values = ParseValues("""{"name":"Alice"}""");
+
+            // Act
+            var first = service.RenderTemplate(templateId, values, "en");
+            var second = service.RenderTemplate(templateId, values, "en");
+
+            // Assert
+            Assert.NotNull(first);
+            Assert.NotNull(second);
+            Assert.Equal(first!.Subject, second!.Subject);
+        }
+        finally
+        {
+            File.Delete(templatePath);
+        }
+    }
 }

--- a/tests/electrostoreNOTIF/Services/WebPushServiceTests.cs
+++ b/tests/electrostoreNOTIF/Services/WebPushServiceTests.cs
@@ -103,4 +103,47 @@ public class WebPushServiceTests
         // Assert
         Assert.Null(exception);
     }
+
+    // Freshly generated (via WebPush's own VapidHelper.GenerateVapidKeys()) throwaway test keypair -
+    // not tied to any real deployment - used only so VapidDetails construction succeeds.
+    private static Dictionary<string, string?> EnabledVapidValues() => new()
+    {
+        ["VAPID:PublicKey"] = "BLlwbWnHyXySQ6_MXzqmfIB8Qs72kdgI3j0a2L0MAMz65sIa-xnTyNj-UDax1b-d-heJOep4vwo1OttXqVS02Yk",
+        ["VAPID:PrivateKey"] = "Ch-bCoWZqAOnD6UM4D-Xl1PZhlW8FMSzl1wRON5u29c",
+        ["VAPID:Enable"] = "true"
+    };
+
+    [Fact]
+    public async Task SendAsync_ShouldThrowInvalidOperationException_WhenPushServiceIsUnreachable()
+    {
+        // VAPID enabled drives execution into the real send attempt (WebPushClient isn't
+        // injected/mockable). Port 1 has nobody listening, so the connection is refused
+        // immediately, exercising SendAsync's generic catch-and-wrap branch deterministically.
+        // Arrange
+        var service = CreateService(EnabledVapidValues());
+
+        // Act
+        var exception = await Record.ExceptionAsync(() =>
+            service.SendAsync("http://127.0.0.1:1/push-endpoint", "p256dh-key", "auth-key", "Title", "Body"));
+
+        // Assert
+        Assert.IsType<InvalidOperationException>(exception);
+        Assert.Contains("Failed to send push notification", exception!.Message);
+    }
+
+    [Fact]
+    public async Task SendAsync_ShouldThrowInvalidOperationException_WhenPushServiceIsUnreachable_WithData()
+    {
+        // Same as above but exercising the optional "data" payload branch.
+        // Arrange
+        var service = CreateService(EnabledVapidValues());
+        var data = new Dictionary<string, string> { ["orderId"] = "123" };
+
+        // Act
+        var exception = await Record.ExceptionAsync(() =>
+            service.SendAsync("http://127.0.0.1:1/push-endpoint", "p256dh-key", "auth-key", "Title", "Body", data));
+
+        // Assert
+        Assert.IsType<InvalidOperationException>(exception);
+    }
 }

--- a/tests/electrostoreWORKER/Extensions/VaultConfigurationExtensionsTests.cs
+++ b/tests/electrostoreWORKER/Extensions/VaultConfigurationExtensionsTests.cs
@@ -142,4 +142,33 @@ public class VaultConfigurationExtensionsTests
         // Assert
         Assert.Equal("plain-value", result["SomeSetting"]);
     }
+
+    [Fact]
+    public void AddVaultConfiguration_ShouldThrowInvalidOperationException_WhenSecretRetrievalFails()
+    {
+        // A config value references a vault secret ("{{vault:...}}"), which drives execution into
+        // the placeholder-substitution loop and the actual Vault HTTP call. Port 1 has nobody
+        // listening, so the connection is refused immediately (no DNS/timeout delay), letting
+        // GetVaultSecret's catch-and-wrap branch be exercised deterministically and fast.
+        // Note: the value must live under a nested key (e.g. "App:ApiKey") - SearchInConfigBranch
+        // only inspects the *children* of each top-level section, so a flat top-level key is
+        // never checked for a vault placeholder.
+        // Arrange
+        var builder = BuildConfigBuilder(new Dictionary<string, string?>
+        {
+            ["Vault:Enable"] = "true",
+            ["Vault:Addr"] = "http://127.0.0.1:1",
+            ["Vault:Token"] = "token",
+            ["Vault:Path"] = "secret/path",
+            ["Vault:MountPoint"] = "secret",
+            ["App:ApiKey"] = "prefix-{{vault:api-key}}-suffix"
+        });
+
+        // Act
+        var exception = Assert.Throws<InvalidOperationException>(() => builder.AddVaultConfiguration());
+
+        // Assert
+        Assert.Contains("Failed to retrieve secret from Vault", exception.Message);
+        Assert.Contains("api-key", exception.Message);
+    }
 }

--- a/tests/electrostoreWORKER/Kafka/Consumers/KafkaIaStatusConsumerTests.cs
+++ b/tests/electrostoreWORKER/Kafka/Consumers/KafkaIaStatusConsumerTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Confluent.Kafka;
 using ElectrostoreWORKER.Grpc;
 using ElectrostoreWORKER.Kafka.Consumers;
 using ElectrostoreWORKER.Kafka.Messages;
@@ -7,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
+using Metadata = Grpc.Core.Metadata;
 
 namespace ElectrostoreWORKER.Tests.Kafka.Consumers;
 
@@ -19,6 +21,37 @@ public class KafkaIaStatusConsumerTests
     {
         var configuration = new ConfigurationBuilder().Build();
         return new KafkaIaStatusConsumer(_iaTrainingClient.Object, configuration, _logger.Object);
+    }
+
+    private static ConsumeResult<string, string> CreateConsumeResult(string? value, bool isPartitionEOF = false, long offset = 1)
+    {
+        return new ConsumeResult<string, string>
+        {
+            Message = value is null ? null : new Message<string, string> { Value = value },
+            IsPartitionEOF = isPartitionEOF,
+            Offset = offset
+        };
+    }
+
+    private static Task<ConsumeResult<string, string>?> ConsumeMessageAsync(KafkaIaStatusConsumer consumer, IConsumer<string, string> kafkaConsumer, CancellationToken ct = default)
+    {
+        var method = typeof(KafkaIaStatusConsumer).GetMethod("ConsumeMessageAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ConsumeMessageAsync method not found");
+        return (Task<ConsumeResult<string, string>?>)method.Invoke(consumer, new object[] { kafkaConsumer, ct })!;
+    }
+
+    private static Task ProcessMessageAsync(KafkaIaStatusConsumer consumer, IConsumer<string, string> kafkaConsumer, ConsumeResult<string, string> result, CancellationToken ct = default)
+    {
+        var method = typeof(KafkaIaStatusConsumer).GetMethod("ProcessMessageAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ProcessMessageAsync method not found");
+        return (Task)method.Invoke(consumer, new object[] { kafkaConsumer, result, ct })!;
+    }
+
+    private static IaStatusMessage? DeserializeMessage(KafkaIaStatusConsumer consumer, ConsumeResult<string, string> result)
+    {
+        var method = typeof(KafkaIaStatusConsumer).GetMethod("DeserializeMessage", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("DeserializeMessage method not found");
+        return (IaStatusMessage?)method.Invoke(consumer, new object[] { result });
     }
 
     private static AsyncUnaryCall<TResponse> CreateAsyncUnaryCall<TResponse>(TResponse response)
@@ -92,5 +125,174 @@ public class KafkaIaStatusConsumerTests
 
         // Assert
         Assert.Null(exception);
+    }
+
+    // ---- DeserializeMessage ----
+
+    [Fact]
+    public void DeserializeMessage_ShouldReturnMessage_WhenJsonIsValid()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var result = CreateConsumeResult("""{"action":"training_completed","id_ia":7}""");
+
+        // Act
+        var msg = DeserializeMessage(consumer, result);
+
+        // Assert
+        Assert.NotNull(msg);
+        Assert.Equal("training_completed", msg!.action);
+        Assert.Equal(7, msg.id_ia);
+    }
+
+    [Fact]
+    public void DeserializeMessage_ShouldReturnNull_WhenJsonIsInvalid()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var result = CreateConsumeResult("{not-json");
+
+        // Act
+        var msg = DeserializeMessage(consumer, result);
+
+        // Assert
+        Assert.Null(msg);
+    }
+
+    // ---- ConsumeMessageAsync ----
+
+    [Fact]
+    public async Task ConsumeMessageAsync_ShouldReturnResult_WhenConsumeSucceeds()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var expected = CreateConsumeResult("""{"action":"training_completed","id_ia":1}""");
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        kafkaConsumer.Setup(c => c.Consume(It.IsAny<CancellationToken>())).Returns(expected);
+
+        // Act
+        var result = await ConsumeMessageAsync(consumer, kafkaConsumer.Object);
+
+        // Assert
+        Assert.Same(expected, result);
+    }
+
+    [Fact]
+    public async Task ConsumeMessageAsync_ShouldReturnNull_WhenOperationIsCancelled()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        kafkaConsumer.Setup(c => c.Consume(It.IsAny<CancellationToken>())).Throws<OperationCanceledException>();
+
+        // Act
+        var result = await ConsumeMessageAsync(consumer, kafkaConsumer.Object);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ConsumeMessageAsync_ShouldReturnNull_WhenConsumeExceptionIsThrown()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        kafkaConsumer
+            .Setup(c => c.Consume(It.IsAny<CancellationToken>()))
+            .Throws(new ConsumeException(new ConsumeResult<byte[], byte[]>(), new Error(ErrorCode.UnknownTopicOrPart)));
+
+        // Act
+        var result = await ConsumeMessageAsync(consumer, kafkaConsumer.Object);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    // ---- ProcessMessageAsync ----
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldDoNothing_WhenResultIsPartitionEOF()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult(null, isPartitionEOF: true);
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        kafkaConsumer.Verify(c => c.Commit(It.IsAny<ConsumeResult<string, string>>()), Times.Never);
+        _iaTrainingClient.Verify(c => c.UpdateIaStatusAsync(It.IsAny<UpdateIaStatusRequest>(), It.IsAny<Metadata>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldDoNothing_WhenMessageValueIsNull()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult(null);
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        kafkaConsumer.Verify(c => c.Commit(It.IsAny<ConsumeResult<string, string>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldCommitWithoutDispatching_WhenJsonIsInvalid()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult("{not-json");
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        kafkaConsumer.Verify(c => c.Commit(result), Times.Once);
+        _iaTrainingClient.Verify(c => c.UpdateIaStatusAsync(It.IsAny<UpdateIaStatusRequest>(), It.IsAny<Metadata>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldDispatchAndCommit_WhenMessageIsValid()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult("""{"action":"training_completed","id_ia":9}""");
+        _iaTrainingClient
+            .Setup(c => c.UpdateIaStatusAsync(It.IsAny<UpdateIaStatusRequest>(), It.IsAny<Metadata>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .Returns(CreateAsyncUnaryCall(new UpdateIaStatusReply { Success = true }));
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        _iaTrainingClient.Verify(c => c.UpdateIaStatusAsync(It.Is<UpdateIaStatusRequest>(r => r.IdIa == 9), It.IsAny<Metadata>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()), Times.Once);
+        kafkaConsumer.Verify(c => c.Commit(result), Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldNotCommitOrThrow_WhenDispatchThrows()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult("""{"action":"training_completed","id_ia":9}""");
+        _iaTrainingClient
+            .Setup(c => c.UpdateIaStatusAsync(It.IsAny<UpdateIaStatusRequest>(), It.IsAny<Metadata>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .Throws(new RpcException(new Status(StatusCode.Unavailable, "down")));
+
+        // Act
+        var exception = await Record.ExceptionAsync(() => ProcessMessageAsync(consumer, kafkaConsumer.Object, result));
+
+        // Assert
+        Assert.Null(exception);
+        kafkaConsumer.Verify(c => c.Commit(It.IsAny<ConsumeResult<string, string>>()), Times.Never);
     }
 }

--- a/tests/electrostoreWORKER/Kafka/Consumers/KafkaMqttUserConsumerTests.cs
+++ b/tests/electrostoreWORKER/Kafka/Consumers/KafkaMqttUserConsumerTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Confluent.Kafka;
 using ElectrostoreWORKER.Kafka.Consumers;
 using ElectrostoreWORKER.Kafka.Messages;
 using Microsoft.Extensions.Configuration;
@@ -26,6 +27,37 @@ public class KafkaMqttUserConsumerTests
         var method = typeof(KafkaMqttUserConsumer).GetMethod("DispatchAsync", BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("DispatchAsync method not found");
         return (Task)method.Invoke(consumer, new object[] { message, ct })!;
+    }
+
+    private static ConsumeResult<string, string> CreateConsumeResult(string? value, bool isPartitionEOF = false, long offset = 1)
+    {
+        return new ConsumeResult<string, string>
+        {
+            Message = value is null ? null : new Message<string, string> { Value = value },
+            IsPartitionEOF = isPartitionEOF,
+            Offset = offset
+        };
+    }
+
+    private static Task<ConsumeResult<string, string>?> ConsumeMessageAsync(KafkaMqttUserConsumer consumer, IConsumer<string, string> kafkaConsumer, CancellationToken ct = default)
+    {
+        var method = typeof(KafkaMqttUserConsumer).GetMethod("ConsumeMessageAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ConsumeMessageAsync method not found");
+        return (Task<ConsumeResult<string, string>?>)method.Invoke(consumer, new object[] { kafkaConsumer, ct })!;
+    }
+
+    private static Task ProcessMessageAsync(KafkaMqttUserConsumer consumer, IConsumer<string, string> kafkaConsumer, ConsumeResult<string, string> result, CancellationToken ct = default)
+    {
+        var method = typeof(KafkaMqttUserConsumer).GetMethod("ProcessMessageAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ProcessMessageAsync method not found");
+        return (Task)method.Invoke(consumer, new object[] { kafkaConsumer, result, ct })!;
+    }
+
+    private static MqttUserMessage? DeserializeMessage(KafkaMqttUserConsumer consumer, ConsumeResult<string, string> result)
+    {
+        var method = typeof(KafkaMqttUserConsumer).GetMethod("DeserializeMessage", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("DeserializeMessage method not found");
+        return (MqttUserMessage?)method.Invoke(consumer, new object[] { result });
     }
 
     [Fact]
@@ -68,5 +100,150 @@ public class KafkaMqttUserConsumerTests
 
         // Assert
         Assert.Null(exception);
+    }
+
+    // ---- DeserializeMessage ----
+
+    [Fact]
+    public void DeserializeMessage_ShouldReturnMessage_WhenJsonIsValid()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var result = CreateConsumeResult("""{"user":"alice","password":"secret"}""");
+
+        // Act
+        var msg = DeserializeMessage(consumer, result);
+
+        // Assert
+        Assert.NotNull(msg);
+        Assert.Equal("alice", msg!.user);
+    }
+
+    [Fact]
+    public void DeserializeMessage_ShouldReturnNull_WhenJsonIsInvalid()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var result = CreateConsumeResult("{not-json");
+
+        // Act
+        var msg = DeserializeMessage(consumer, result);
+
+        // Assert
+        Assert.Null(msg);
+    }
+
+    // ---- ConsumeMessageAsync ----
+
+    [Fact]
+    public async Task ConsumeMessageAsync_ShouldReturnResult_WhenConsumeSucceeds()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var expected = CreateConsumeResult("""{"user":"alice","password":"secret"}""");
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        kafkaConsumer.Setup(c => c.Consume(It.IsAny<CancellationToken>())).Returns(expected);
+
+        // Act
+        var result = await ConsumeMessageAsync(consumer, kafkaConsumer.Object);
+
+        // Assert
+        Assert.Same(expected, result);
+    }
+
+    [Fact]
+    public async Task ConsumeMessageAsync_ShouldReturnNull_WhenOperationIsCancelled()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        kafkaConsumer.Setup(c => c.Consume(It.IsAny<CancellationToken>())).Throws<OperationCanceledException>();
+
+        // Act
+        var result = await ConsumeMessageAsync(consumer, kafkaConsumer.Object);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ConsumeMessageAsync_ShouldReturnNull_WhenConsumeExceptionIsThrown()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        kafkaConsumer
+            .Setup(c => c.Consume(It.IsAny<CancellationToken>()))
+            .Throws(new ConsumeException(new ConsumeResult<byte[], byte[]>(), new Error(ErrorCode.UnknownTopicOrPart)));
+
+        // Act
+        var result = await ConsumeMessageAsync(consumer, kafkaConsumer.Object);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    // ---- ProcessMessageAsync ----
+    // Only scenarios that do not require a valid/successful dispatch are exercised here,
+    // since a successful dispatch would reach the real, unmockable Docker client.
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldDoNothing_WhenResultIsPartitionEOF()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult(null, isPartitionEOF: true);
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        kafkaConsumer.Verify(c => c.Commit(It.IsAny<ConsumeResult<string, string>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldDoNothing_WhenMessageValueIsNull()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult(null);
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        kafkaConsumer.Verify(c => c.Commit(It.IsAny<ConsumeResult<string, string>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldCommitWithoutDispatching_WhenJsonIsInvalid()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult("{not-json");
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        kafkaConsumer.Verify(c => c.Commit(result), Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldNotCommit_WhenMessageFailsValidation()
+    {
+        // Arrange - missing password fails validation before touching Docker, DispatchAsync returns false
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult("""{"user":"alice","password":""}""");
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        kafkaConsumer.Verify(c => c.Commit(It.IsAny<ConsumeResult<string, string>>()), Times.Never);
     }
 }

--- a/tests/electrostoreWORKER/Kafka/Consumers/KafkaTrackingResultConsumerTests.cs
+++ b/tests/electrostoreWORKER/Kafka/Consumers/KafkaTrackingResultConsumerTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Confluent.Kafka;
 using ElectrostoreWORKER.Grpc;
 using ElectrostoreWORKER.Kafka.Consumers;
 using ElectrostoreWORKER.Kafka.Messages;
@@ -7,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
+using Metadata = Grpc.Core.Metadata;
 
 namespace ElectrostoreWORKER.Tests.Kafka.Consumers;
 
@@ -36,6 +38,37 @@ public class KafkaTrackingResultConsumerTests
         var method = typeof(KafkaTrackingResultConsumer).GetMethod("DispatchAsync", BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("DispatchAsync method not found");
         return (Task)method.Invoke(consumer, new object[] { message, ct })!;
+    }
+
+    private static ConsumeResult<string, string> CreateConsumeResult(string? value, bool isPartitionEOF = false, long offset = 1)
+    {
+        return new ConsumeResult<string, string>
+        {
+            Message = value is null ? null : new Message<string, string> { Value = value },
+            IsPartitionEOF = isPartitionEOF,
+            Offset = offset
+        };
+    }
+
+    private static Task<ConsumeResult<string, string>?> ConsumeMessageAsync(KafkaTrackingResultConsumer consumer, IConsumer<string, string> kafkaConsumer, CancellationToken ct = default)
+    {
+        var method = typeof(KafkaTrackingResultConsumer).GetMethod("ConsumeMessageAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ConsumeMessageAsync method not found");
+        return (Task<ConsumeResult<string, string>?>)method.Invoke(consumer, new object[] { kafkaConsumer, ct })!;
+    }
+
+    private static Task ProcessMessageAsync(KafkaTrackingResultConsumer consumer, IConsumer<string, string> kafkaConsumer, ConsumeResult<string, string> result, CancellationToken ct = default)
+    {
+        var method = typeof(KafkaTrackingResultConsumer).GetMethod("ProcessMessageAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("ProcessMessageAsync method not found");
+        return (Task)method.Invoke(consumer, new object[] { kafkaConsumer, result, ct })!;
+    }
+
+    private static TrackingResultMessage? DeserializeMessage(KafkaTrackingResultConsumer consumer, ConsumeResult<string, string> result)
+    {
+        var method = typeof(KafkaTrackingResultConsumer).GetMethod("DeserializeMessage", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("DeserializeMessage method not found");
+        return (TrackingResultMessage?)method.Invoke(consumer, new object[] { result });
     }
 
     [Fact]
@@ -143,5 +176,188 @@ public class KafkaTrackingResultConsumerTests
         // Assert
         Assert.Null(exception);
         _commandsClient.Verify(c => c.UpdateCommandStatusAsync(It.IsAny<UpdateCommandStatusRequest>(), It.IsAny<Metadata>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ---- DeserializeMessage ----
+
+    [Fact]
+    public void DeserializeMessage_ShouldReturnMessage_WhenJsonIsValid()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var result = CreateConsumeResult("""{"action":"register","tracking_number":"TN9","carrier":1,"success":true}""");
+
+        // Act
+        var msg = DeserializeMessage(consumer, result);
+
+        // Assert
+        Assert.NotNull(msg);
+        Assert.Equal("TN9", msg!.tracking_number);
+    }
+
+    [Fact]
+    public void DeserializeMessage_ShouldReturnNull_WhenJsonIsInvalid()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var result = CreateConsumeResult("{not-json");
+
+        // Act
+        var msg = DeserializeMessage(consumer, result);
+
+        // Assert
+        Assert.Null(msg);
+    }
+
+    // ---- ConsumeMessageAsync ----
+
+    [Fact]
+    public async Task ConsumeMessageAsync_ShouldReturnResult_WhenConsumeSucceeds()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var expected = CreateConsumeResult("""{"action":"register","tracking_number":"TN1","carrier":1,"success":true}""");
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        kafkaConsumer.Setup(c => c.Consume(It.IsAny<CancellationToken>())).Returns(expected);
+
+        // Act
+        var result = await ConsumeMessageAsync(consumer, kafkaConsumer.Object);
+
+        // Assert
+        Assert.Same(expected, result);
+    }
+
+    [Fact]
+    public async Task ConsumeMessageAsync_ShouldReturnNull_WhenOperationIsCancelled()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        kafkaConsumer.Setup(c => c.Consume(It.IsAny<CancellationToken>())).Throws<OperationCanceledException>();
+
+        // Act
+        var result = await ConsumeMessageAsync(consumer, kafkaConsumer.Object);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task ConsumeMessageAsync_ShouldReturnNull_WhenConsumeExceptionIsThrown()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        kafkaConsumer
+            .Setup(c => c.Consume(It.IsAny<CancellationToken>()))
+            .Throws(new ConsumeException(new ConsumeResult<byte[], byte[]>(), new Error(ErrorCode.UnknownTopicOrPart)));
+
+        // Act
+        var result = await ConsumeMessageAsync(consumer, kafkaConsumer.Object);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    // ---- ProcessMessageAsync ----
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldDoNothing_WhenResultIsPartitionEOF()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult(null, isPartitionEOF: true);
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        kafkaConsumer.Verify(c => c.Commit(It.IsAny<ConsumeResult<string, string>>()), Times.Never);
+        _commandsClient.Verify(c => c.UpdateCommandStatusAsync(It.IsAny<UpdateCommandStatusRequest>(), It.IsAny<Metadata>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldDoNothing_WhenMessageValueIsNull()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult(null);
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        kafkaConsumer.Verify(c => c.Commit(It.IsAny<ConsumeResult<string, string>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldCommitWithoutDispatching_WhenJsonIsInvalid()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult("{not-json");
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        kafkaConsumer.Verify(c => c.Commit(result), Times.Once);
+        _commandsClient.Verify(c => c.UpdateCommandStatusAsync(It.IsAny<UpdateCommandStatusRequest>(), It.IsAny<Metadata>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldDispatchAndCommit_WhenMessageIsValid()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult("""{"action":"register","tracking_number":"TN5","carrier":3,"success":true}""");
+        _commandsClient
+            .Setup(c => c.UpdateCommandStatusAsync(It.IsAny<UpdateCommandStatusRequest>(), It.IsAny<Metadata>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .Returns(CreateAsyncUnaryCall(new UpdateCommandStatusReply { Success = true }));
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        _commandsClient.Verify(c => c.UpdateCommandStatusAsync(It.Is<UpdateCommandStatusRequest>(r => r.TrackingNumber == "TN5"), It.IsAny<Metadata>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()), Times.Once);
+        kafkaConsumer.Verify(c => c.Commit(result), Times.Once);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldNotCommit_WhenTrackingFailed()
+    {
+        // Arrange - DispatchAsync returns false when the tracking event itself reports failure
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult("""{"action":"register","tracking_number":"TN6","carrier":3,"success":false,"error_code":5}""");
+
+        // Act
+        await ProcessMessageAsync(consumer, kafkaConsumer.Object, result);
+
+        // Assert
+        kafkaConsumer.Verify(c => c.Commit(It.IsAny<ConsumeResult<string, string>>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessMessageAsync_ShouldNotCommitOrThrow_WhenDispatchThrows()
+    {
+        // Arrange
+        var consumer = CreateConsumer();
+        var kafkaConsumer = new Mock<IConsumer<string, string>>();
+        var result = CreateConsumeResult("""{"action":"register","tracking_number":"TN7","carrier":3,"success":true}""");
+        _commandsClient
+            .Setup(c => c.UpdateCommandStatusAsync(It.IsAny<UpdateCommandStatusRequest>(), It.IsAny<Metadata>(), It.IsAny<DateTime?>(), It.IsAny<CancellationToken>()))
+            .Throws(new RpcException(new Status(StatusCode.Unavailable, "down")));
+
+        // Act
+        var exception = await Record.ExceptionAsync(() => ProcessMessageAsync(consumer, kafkaConsumer.Object, result));
+
+        // Assert
+        Assert.Null(exception);
+        kafkaConsumer.Verify(c => c.Commit(It.IsAny<ConsumeResult<string, string>>()), Times.Never);
     }
 }

--- a/tests/electrostoreWORKER/Mqtt/MqttClientServiceTests.cs
+++ b/tests/electrostoreWORKER/Mqtt/MqttClientServiceTests.cs
@@ -1,19 +1,23 @@
 using System.Reflection;
+using System.Text;
 using ElectrostoreWORKER.Grpc;
 using ElectrostoreWORKER.Mqtt;
 using Grpc.Core;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
+using MQTTnet;
+using MQTTnet.Packets;
 using Xunit;
 
 namespace ElectrostoreWORKER.Tests.Mqtt;
 
 public class MqttClientServiceTests
 {
-    // MqttClientService.ExecuteAsync opens a real TCP/MQTT connection and OnMessageReceivedAsync
-    // takes an MQTTnet event-args type with no public constructor suited for unit tests, so
-    // coverage focuses on UpdateStoreMqttStatusAsync, the private method that owns the gRPC call.
+    // MqttClientService.ExecuteAsync opens a real TCP/MQTT connection, so it isn't unit-tested here.
+    // OnMessageReceivedAsync and UpdateStoreMqttStatusAsync, the private methods that own the topic
+    // parsing and the gRPC call, are covered via MqttApplicationMessageReceivedEventArgs's public
+    // constructor.
     private readonly Mock<StoresMqttGrpc.StoresMqttGrpcClient> _grpcClient = new();
     private readonly Mock<ILogger<MqttClientService>> _logger = new();
 
@@ -38,6 +42,23 @@ public class MqttClientServiceTests
         var method = typeof(MqttClientService).GetMethod("UpdateStoreMqttStatusAsync", BindingFlags.NonPublic | BindingFlags.Instance)
             ?? throw new InvalidOperationException("UpdateStoreMqttStatusAsync method not found");
         return (Task)method.Invoke(service, new object[] { mqttNameStore, isConnected })!;
+    }
+
+    private static MqttApplicationMessageReceivedEventArgs CreateReceivedEventArgs(string topic, string? payload)
+    {
+        var message = new MqttApplicationMessage
+        {
+            Topic = topic,
+            PayloadSegment = payload is null ? default : new ArraySegment<byte>(Encoding.UTF8.GetBytes(payload))
+        };
+        return new MqttApplicationMessageReceivedEventArgs("test-client", message, new MqttPublishPacket(), (_, _) => Task.CompletedTask);
+    }
+
+    private static Task OnMessageReceivedAsync(MqttClientService service, MqttApplicationMessageReceivedEventArgs args)
+    {
+        var method = typeof(MqttClientService).GetMethod("OnMessageReceivedAsync", BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("OnMessageReceivedAsync method not found");
+        return (Task)method.Invoke(service, new object[] { args })!;
     }
 
     [Fact]
@@ -88,5 +109,90 @@ public class MqttClientServiceTests
 
         // Assert
         Assert.Null(exception);
+    }
+
+    // ---- OnMessageReceivedAsync ----
+
+    [Theory]
+    [InlineData("1")]
+    [InlineData("true")]
+    [InlineData("online")]
+    public async Task OnMessageReceivedAsync_ShouldReportConnected_ForRecognizedOnlinePayloads(string payload)
+    {
+        // Arrange
+        var service = CreateService();
+        var tcs = new TaskCompletionSource();
+        _grpcClient
+            .Setup(c => c.UpdateStoreMqttStatusAsync(It.IsAny<UpdateStoreMqttStatusRequest>(), null, null, default))
+            .Callback(() => tcs.TrySetResult())
+            .Returns(CreateAsyncUnaryCall(new UpdateStoreMqttStatusReply { Success = true, StoreCount = 1 }));
+        var args = CreateReceivedEventArgs("electrostore/store-1/status", payload);
+
+        // Act
+        await OnMessageReceivedAsync(service, args);
+        await tcs.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        // Assert
+        _grpcClient.Verify(c => c.UpdateStoreMqttStatusAsync(
+            It.Is<UpdateStoreMqttStatusRequest>(r => r.MqttNameStore == "store-1" && r.IsMqttConnected),
+            null, null, default), Times.Once);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("offline")]
+    [InlineData("")]
+    public async Task OnMessageReceivedAsync_ShouldReportDisconnected_ForOtherPayloads(string payload)
+    {
+        // Arrange
+        var service = CreateService();
+        var tcs = new TaskCompletionSource();
+        _grpcClient
+            .Setup(c => c.UpdateStoreMqttStatusAsync(It.IsAny<UpdateStoreMqttStatusRequest>(), null, null, default))
+            .Callback(() => tcs.TrySetResult())
+            .Returns(CreateAsyncUnaryCall(new UpdateStoreMqttStatusReply { Success = true, StoreCount = 1 }));
+        var args = CreateReceivedEventArgs("electrostore/store-2/status", payload);
+
+        // Act
+        await OnMessageReceivedAsync(service, args);
+        await tcs.Task.WaitAsync(TimeSpan.FromSeconds(2));
+
+        // Assert
+        _grpcClient.Verify(c => c.UpdateStoreMqttStatusAsync(
+            It.Is<UpdateStoreMqttStatusRequest>(r => r.MqttNameStore == "store-2" && !r.IsMqttConnected),
+            null, null, default), Times.Once);
+    }
+
+    [Theory]
+    [InlineData("not/a/status/topic")]
+    [InlineData("electrostore/store-1/other")]
+    [InlineData("other/electrostore/status")]
+    public async Task OnMessageReceivedAsync_ShouldNotCallApi_WhenTopicDoesNotMatchExpectedShape(string topic)
+    {
+        // Arrange
+        var service = CreateService();
+        var args = CreateReceivedEventArgs(topic, "online");
+
+        // Act
+        await OnMessageReceivedAsync(service, args);
+        await Task.Delay(50);
+
+        // Assert
+        _grpcClient.Verify(c => c.UpdateStoreMqttStatusAsync(It.IsAny<UpdateStoreMqttStatusRequest>(), null, null, default), Times.Never);
+    }
+
+    [Fact]
+    public async Task OnMessageReceivedAsync_ShouldNotCallApi_WhenMqttNameIsEmpty()
+    {
+        // Arrange
+        var service = CreateService();
+        var args = CreateReceivedEventArgs("electrostore//status", "online");
+
+        // Act
+        await OnMessageReceivedAsync(service, args);
+        await Task.Delay(50);
+
+        // Assert
+        _grpcClient.Verify(c => c.UpdateStoreMqttStatusAsync(It.IsAny<UpdateStoreMqttStatusRequest>(), null, null, default), Times.Never);
     }
 }

--- a/tests/electrostoreWORKER/ProgramTests.cs
+++ b/tests/electrostoreWORKER/ProgramTests.cs
@@ -1,0 +1,86 @@
+using System.Reflection;
+using ElectrostoreWORKER.Grpc;
+using ElectrostoreWORKER.Kafka.Consumers;
+using ElectrostoreWORKER.Mqtt;
+using ElectrostoreWORKER.Services.ConfigCacheService;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using Xunit;
+
+namespace ElectrostoreWORKER.Tests;
+
+public class ProgramTests
+{
+    // Program.Main() itself requires a real "config/appsettings.json" file and live infrastructure
+    // (Kafka, Docker, MQTT broker) once the hosted services start, so it isn't exercised directly.
+    // AddScopes is the private static method that owns the DI wiring and can be tested in isolation
+    // by inspecting the resulting IServiceCollection without building/starting the host.
+    private static void InvokeAddScopes(WebApplicationBuilder builder)
+    {
+        var method = typeof(Program).GetMethod("AddScopes", BindingFlags.NonPublic | BindingFlags.Static)
+            ?? throw new InvalidOperationException("AddScopes method not found");
+        method.Invoke(null, new object[] { builder });
+    }
+
+    [Fact]
+    public void AddScopes_ShouldRegisterConfigCacheService_AsSingletonAndAsItsInterface()
+    {
+        // Arrange
+        var builder = WebApplication.CreateBuilder();
+
+        // Act
+        InvokeAddScopes(builder);
+
+        // Assert
+        Assert.Contains(builder.Services, d => d.ServiceType == typeof(ConfigCacheService) && d.Lifetime == ServiceLifetime.Singleton);
+        Assert.Contains(builder.Services, d => d.ServiceType == typeof(IConfigCacheService) && d.Lifetime == ServiceLifetime.Singleton);
+    }
+
+    [Fact]
+    public void AddScopes_ShouldRegisterAllExpectedHostedServices()
+    {
+        // Arrange
+        var builder = WebApplication.CreateBuilder();
+
+        // Act
+        InvokeAddScopes(builder);
+
+        // Assert - ConfigCacheService (via factory) + the 3 Kafka consumers + the MQTT client
+        var hostedServiceDescriptors = builder.Services.Where(d => d.ServiceType == typeof(IHostedService)).ToList();
+        Assert.Equal(5, hostedServiceDescriptors.Count);
+        Assert.Contains(hostedServiceDescriptors, d => d.ImplementationType == typeof(KafkaIaStatusConsumer));
+        Assert.Contains(hostedServiceDescriptors, d => d.ImplementationType == typeof(KafkaMqttUserConsumer));
+        Assert.Contains(hostedServiceDescriptors, d => d.ImplementationType == typeof(KafkaTrackingResultConsumer));
+        Assert.Contains(hostedServiceDescriptors, d => d.ImplementationType == typeof(MqttClientService));
+    }
+
+    [Fact]
+    public void AddScopes_ShouldResolveConfigCacheServiceHostedServiceToSameSingletonInstance()
+    {
+        // The ConfigCacheService hosted-service registration uses a factory that must resolve to
+        // the very same singleton instance also exposed as IConfigCacheService, so the cache state
+        // observed by consumers matches the instance the host actually starts/stops.
+        // Arrange
+        var builder = WebApplication.CreateBuilder();
+        InvokeAddScopes(builder);
+        // The hosted services depend on generated gRPC clients, which AddScopes doesn't register
+        // (Program.Main wires them separately via AddGrpcClient) - supply mocks so that resolving
+        // IHostedService (which activates every registered hosted service) succeeds.
+        builder.Services.AddSingleton(new Mock<ConfigGrpc.ConfigGrpcClient>().Object);
+        builder.Services.AddSingleton(new Mock<IaTrainingGrpc.IaTrainingGrpcClient>().Object);
+        builder.Services.AddSingleton(new Mock<CommandsGrpc.CommandsGrpcClient>().Object);
+        builder.Services.AddSingleton(new Mock<StoresMqttGrpc.StoresMqttGrpcClient>().Object);
+        using var provider = builder.Services.BuildServiceProvider();
+
+        // Act
+        var configCacheService = provider.GetRequiredService<ConfigCacheService>();
+        var configCacheInterface = provider.GetRequiredService<IConfigCacheService>();
+        var hostedConfigCacheService = provider.GetServices<IHostedService>().OfType<ConfigCacheService>().Single();
+
+        // Assert
+        Assert.Same(configCacheService, configCacheInterface);
+        Assert.Same(configCacheService, hostedConfigCacheService);
+    }
+}


### PR DESCRIPTION
Introduces a reusable GitHub composite action that polls SonarQube and writes quality gate and key metrics to job summaries, then wires it into PR and main test workflows for all services. Also hardens Kafka consumer message processing in CRON/NOTIF/WORKER by catching dispatch exceptions so failures are logged without crashing processing loops, and adds broad test coverage for these paths plus DI registrations, vault failure handling, MQTT message parsing, template rendering edge cases, SMTP/web-push error paths, and producer/service lifecycle behavior.