### PR TITLE
feat: Add staged nested resource save helpers

### DIFF
--- a/electrostoreFRONT/src/helpers/nestedResource.js
+++ b/electrostoreFRONT/src/helpers/nestedResource.js
@@ -2,8 +2,8 @@ import { fetchWrapper, buildQuery } from "@/helpers";
 
 const baseUrl = `${import.meta.env.VITE_API_URL}`;
 
-export function createNestedResource({ path, idField, countKey, stateKey, loadingKey, onHydrate }) {
-	return {
+export function createNestedResource({ path, idField, countKey, stateKey, loadingKey, editionKey, readyKey, onHydrate }) {
+	const resource = {
 		async getByInterval(idParentResource, { limit = 100, offset = 0, expand = [], filter = "", sort = "", clear = false, externalParam = [] } = {}) {
 			if (!this[stateKey][String(idParentResource)] || clear) {
 				this[stateKey][String(idParentResource)] = {};
@@ -77,5 +77,58 @@ export function createNestedResource({ path, idField, countKey, stateKey, loadin
 			this[countKey][idParentResource] = (this[countKey][idParentResource] ?? 0) - res.valide.length;
 			this[countKey][idParentResource] = Math.max(this[countKey][idParentResource], 0);
 		},
+		getAvailableNewId(idParentResource) {
+			const edition = this[editionKey][idParentResource] ?? {};
+			let i = 1;
+			while (Object.hasOwn(edition, `new-${i}`)) {
+				i++;
+			}
+			return `new-${i}`;
+		},
+		valideEditionById(idParentResource, id, status = "modified") {
+			this[readyKey][idParentResource] ??= {};
+			const edition = this[editionKey][idParentResource]?.[id] ?? {};
+			this[readyKey][idParentResource][id] = { ...edition, [idField]: id, status };
+		},
+		copyPerId(idParentResource, oldId, newId) {
+			this[editionKey][idParentResource] ??= {};
+			this[readyKey][idParentResource] ??= {};
+			if (this[editionKey][idParentResource][oldId] !== undefined) {
+				this[editionKey][idParentResource][newId] = { ...this[editionKey][idParentResource][oldId], [idField]: newId };
+			}
+			if (this[readyKey][idParentResource][oldId] !== undefined) {
+				this[readyKey][idParentResource][newId] = { ...this[readyKey][idParentResource][oldId], [idField]: newId };
+			}
+		},
+		copyAllId(parentKey, oldIdParentResource, newIdParentResource) {
+			this[editionKey][newIdParentResource] = { ...this[editionKey][oldIdParentResource] };
+			this[readyKey][newIdParentResource] = { ...this[readyKey][oldIdParentResource] };
+			for (const [id, entry] of Object.entries(this[editionKey][newIdParentResource])) {
+				this[editionKey][newIdParentResource][id] = { ...entry, [idField]: id };
+			}
+			for (const [id, entry] of Object.entries(this[readyKey][newIdParentResource])) {
+				this[readyKey][newIdParentResource][id] = { ...entry, [idField]: id };
+			}
+		},
+		async pushChange(idParentResource) {
+			const readyEntries = { ...this[readyKey][idParentResource] };
+			for (const [id, entry] of Object.entries(readyEntries)) {
+				const { status, ...data } = entry;
+				const isNewId = String(id).startsWith("new-");
+				if (data?.pushChange) {
+					continue; // Skip if already pushed
+				}
+				if (status === "created") {
+					delete data[idField];
+					await resource.create.call(this, idParentResource, data);
+				} else if (status === "modified" && !isNewId) {
+					await resource.update.call(this, idParentResource, id, data);
+				} else if (status === "deleted" && !isNewId) {
+					await resource.remove.call(this, idParentResource, id);
+				}
+				entry.pushChange = true;
+			}
+		},
 	};
+	return resource;
 }

--- a/electrostoreFRONT/src/stores/camera.store.js
+++ b/electrostoreFRONT/src/stores/camera.store.js
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 
-import { fetchWrapper, buildQuery, createMainResource } from "@/helpers";
+import { fetchWrapper, createMainResource } from "@/helpers";
 
 const baseUrl = `${import.meta.env.VITE_API_URL}`;
 

--- a/electrostoreFRONT/src/stores/commands.store.js
+++ b/electrostoreFRONT/src/stores/commands.store.js
@@ -1,8 +1,8 @@
 import { defineStore } from "pinia";
 
-import { fetchWrapper, buildQuery, createMainResource, createNestedResource } from "@/helpers";
+import { fetchWrapper, createMainResource, createNestedResource } from "@/helpers";
 
-import { useUsersStore, useItemsStore, useCarriersStore } from "@/stores";
+import { useUsersStore, useCarriersStore } from "@/stores";
 
 const baseUrl = `${import.meta.env.VITE_API_URL}`;
 
@@ -67,6 +67,8 @@ const commentResource = createNestedResource({
 	stateKey: "comments",
 	countKey: "commentsTotalCount",
 	loadingKey: "commentsLoading",
+	editionKey: "commentEdition",
+	readyKey: "commentReady",
 	onHydrate: (store, entity, expand) => {
 		if (expand.includes("user")) {
 			const usersStore = useUsersStore();
@@ -80,6 +82,8 @@ const documentResource = createNestedResource({
 	stateKey: "documents",
 	countKey: "documentsTotalCount",
 	loadingKey: "documentsLoading",
+	editionKey: "documentEdition",
+	readyKey: "documentReady",
 });
 const itemResource = createNestedResource({
 	path: (idCommand) => `/command/${idCommand}/item`,
@@ -87,6 +91,8 @@ const itemResource = createNestedResource({
 	stateKey: "items",
 	countKey: "itemsTotalCount",
 	loadingKey: "itemsLoading",
+	editionKey: "itemEdition",
+	readyKey: "itemReady",
 });
 const historyResource = createNestedResource({
 	path: (idCommand) => `/command/${idCommand}/history`,
@@ -107,16 +113,19 @@ export const useCommandsStore = defineStore("commands",{
 		commentsLoading: false,
 		comments: {},
 		commentEdition: {},
+		commentReady: {},
 
 		documentsTotalCount: {},
 		documentsLoading: false,
 		documents: {},
 		documentEdition: {},
+		documentReady: {},
 
 		itemsTotalCount: {},
 		itemsLoading: false,
 		items: {},
 		itemEdition: {},
+		itemReady: {},
 
 		historyTotalCount: {},
 		historyLoading: false,
@@ -166,8 +175,11 @@ export const useCommandsStore = defineStore("commands",{
 				};
 			}
 			this.commentEdition[id] = {};
+			this.commentReady[id] = {};
 			this.documentEdition[id] = {};
+			this.documentReady[id] = {};
 			this.itemEdition[id] = {};
+			this.itemReady[id] = {};
 		},
 		setLoadingEdition(id, loading) {
 			if (!this.commandEdition[id]) {
@@ -178,8 +190,28 @@ export const useCommandsStore = defineStore("commands",{
 		clearEdition(id) {
 			delete this.commandEdition[id];
 			delete this.commentEdition[id];
+			delete this.commentReady[id];
 			delete this.documentEdition[id];
+			delete this.documentReady[id];
 			delete this.itemEdition[id];
+			delete this.itemReady[id];
+		},
+		async saveAllChanges(id) {
+			let realId = id;
+			if (id === "new") {
+				realId = await this.createCommand(this.commandEdition[id]);
+				this.copyCommentAllId(id, realId);
+				this.copyDocumentAllId(id, realId);
+				this.copyItemAllId(id, realId);
+			} else {
+				await this.updateCommand(id, this.commandEdition[id]);
+			}
+			await Promise.all([
+				this.pushCommentChange(realId),
+				this.pushDocumentChange(realId),
+				this.pushItemChange(realId),
+			]);
+			return realId;
 		},
 
 		getCommentByInterval: commentResource.getByInterval,
@@ -187,12 +219,22 @@ export const useCommandsStore = defineStore("commands",{
 		createComment: commentResource.create,
 		updateComment: commentResource.update,
 		deleteComment: commentResource.remove,
+		getAvailableNewCommentId: commentResource.getAvailableNewId,
+		valideCommentEditionById: commentResource.valideEditionById,
+		copyCommentPerId: commentResource.copyPerId,
+		copyCommentAllId: commentResource.copyAllId,
+		pushCommentChange: commentResource.pushChange,
 
 		getDocumentByInterval: documentResource.getByInterval,
 		getDocumentById: documentResource.getById,
 		createDocument: documentResource.create,
 		updateDocument: documentResource.update,
 		deleteDocument: documentResource.remove,
+		getAvailableNewDocumentId: documentResource.getAvailableNewId,
+		valideDocumentEditionById: documentResource.valideEditionById,
+		copyDocumentPerId: documentResource.copyPerId,
+		copyDocumentAllId: documentResource.copyAllId,
+		pushDocumentChange: documentResource.pushChange,
 		async downloadDocument(idCommand, id) {
 			return await fetchWrapper.image({
 				url: `${baseUrl}/command/${idCommand}/document/${id}/download`,
@@ -206,6 +248,11 @@ export const useCommandsStore = defineStore("commands",{
 		updateItem: itemResource.update,
 		deleteItem: itemResource.remove,
 		createItemBulk: itemResource.createBulk,
+		getAvailableNewItemId: itemResource.getAvailableNewId,
+		valideItemEditionById: itemResource.valideEditionById,
+		copyItemPerId: itemResource.copyPerId,
+		copyItemAllId: itemResource.copyAllId,
+		pushItemChange: itemResource.pushChange,
 
 		getHistoryByInterval: historyResource.getByInterval,
 		getHistoryById: historyResource.getById,

--- a/electrostoreFRONT/src/stores/items.store.js
+++ b/electrostoreFRONT/src/stores/items.store.js
@@ -1,9 +1,8 @@
 import { defineStore } from "pinia";
 
-import { fetchWrapper, buildQuery, createMainResource, createNestedResource } from "@/helpers";
+import { fetchWrapper, createMainResource, createNestedResource } from "@/helpers";
 
-import { useTagsStore, useStoresStore, useCommandsStore, useProjectsStore, useUsersStore } from "@/stores";
-import { onUpdated } from "vue";
+import { useTagsStore, useStoresStore, useCommandsStore, useProjectsStore } from "@/stores";
 
 const baseUrl = `${import.meta.env.VITE_API_URL}`;
 
@@ -90,6 +89,8 @@ const documentResource = createNestedResource({
 	stateKey: "documents",
 	countKey: "documentsTotalCount",
 	loadingKey: "documentsLoading",
+	editionKey: "documentEdition",
+	readyKey: "documentReady",
 });
 const itemBoxResource = createNestedResource({
 	path: (idItem) => `/item/${idItem}/box`,
@@ -97,6 +98,8 @@ const itemBoxResource = createNestedResource({
 	stateKey: "itemBoxs",
 	countKey: "itemBoxsTotalCount",
 	loadingKey: "itemBoxsLoading",
+	editionKey: "itemBoxEdition",
+	readyKey: "itemBoxReady",
 	onHydrate: (store, entity, expand) => {
 		if (expand.includes("box")) {
 			const storeStore = useStoresStore();
@@ -113,6 +116,8 @@ const itemTagResource = createNestedResource({
 	stateKey: "itemTags",
 	countKey: "itemTagsTotalCount",
 	loadingKey: "itemTagsLoading",
+	editionKey: "itemTagEdition",
+	readyKey: "itemTagReady",
 	onHydrate: (store, entity, expand) => {
 		if (expand.includes("tag")) {
 			const tagsStore = useTagsStore();
@@ -126,6 +131,8 @@ const itemCommandResource = createNestedResource({
 	stateKey: "itemCommands",
 	countKey: "itemCommandsTotalCount",
 	loadingKey: "itemCommandsLoading",
+	editionKey: "itemCommandEdition",
+	readyKey: "itemCommandReady",
 	onHydrate: (store, entity, expand) => {
 		if (expand.includes("command")) {
 			const commandsStore = useCommandsStore();
@@ -139,6 +146,8 @@ const itemProjectResource = createNestedResource({
 	stateKey: "itemProjects",
 	countKey: "itemProjectsTotalCount",
 	loadingKey: "itemProjectsLoading",
+	editionKey: "itemProjectEdition",
+	readyKey: "itemProjectReady",
 	onHydrate: (store, entity, expand) => {
 		if (expand.includes("project")) {
 			const projectsStore = useProjectsStore();
@@ -152,6 +161,8 @@ const imageResource = createNestedResource({
 	stateKey: "images",
 	countKey: "imagesTotalCount",
 	loadingKey: "imagesLoading",
+	editionKey: "imageEdition",
+	readyKey: "imageReady",
 	onHydrate: (store, entity, expand, externalParam) => {
 		if (externalParam?.loadImages && !store.imagesURL[entity.id_image]) {
 			store.showImageById(store, externalParam.idItem, entity.id_image);
@@ -190,26 +201,31 @@ export const useItemsStore = defineStore("items",{
 		documentsTotalCount: {},
 		documents: {},
 		documentEdition: {},
+		documentReady: {},
 
 		itemBoxsLoading: false,
 		itemBoxsTotalCount: {},
 		itemBoxs: {},
 		itemBoxEdition: {},
+		itemBoxReady: {},
 
 		itemTagsLoading: false,
 		itemTagsTotalCount: {},
 		itemTags: {},
 		itemTagEdition: {},
+		itemTagReady: {},
 
 		itemCommandsLoading: false,
 		itemCommandsTotalCount: {},
 		itemCommands: {},
 		itemCommandEdition: {},
+		itemCommandReady: {},
 
 		itemProjectsLoading: false,
 		itemProjectsTotalCount: {},
 		itemProjects: {},
 		itemProjectEdition: {},
+		itemProjectReady: {},
 
 		imagesLoading: false,
 		imagesTotalCount: {},
@@ -217,6 +233,7 @@ export const useItemsStore = defineStore("items",{
 		imagesURL: {},
 		thumbnailsURL: {},
 		imageEdition: {},
+		imageReady: {},
 
 		itemHistoryLoading: false,
 		itemHistoryTotalCount: {},
@@ -255,11 +272,17 @@ export const useItemsStore = defineStore("items",{
 				};
 			}
 			this.documentEdition[id] = {};
+			this.documentReady[id] = {};
 			this.itemBoxEdition[id] = {};
+			this.itemBoxReady[id] = {};
 			this.itemTagEdition[id] = {};
+			this.itemTagReady[id] = {};
 			this.itemCommandEdition[id] = {};
+			this.itemCommandReady[id] = {};
 			this.itemProjectEdition[id] = {};
+			this.itemProjectReady[id] = {};
 			this.imageEdition[id] = {};
+			this.imageReady[id] = {};
 		},
 		setLoadingEdition(id, loading) {
 			if (!this.itemEdition[id]) {
@@ -270,11 +293,40 @@ export const useItemsStore = defineStore("items",{
 		clearEdition(id) {
 			delete this.itemEdition[id];
 			delete this.documentEdition[id];
+			delete this.documentReady[id];
 			delete this.itemBoxEdition[id];
+			delete this.itemBoxReady[id];
 			delete this.itemTagEdition[id];
+			delete this.itemTagReady[id];
 			delete this.itemCommandEdition[id];
+			delete this.itemCommandReady[id];
 			delete this.itemProjectEdition[id];
+			delete this.itemProjectReady[id];
 			delete this.imageEdition[id];
+			delete this.imageReady[id];
+		},
+		async saveAllChanges(id) {
+			let realId = id;
+			if (id === "new") {
+				realId = await this.createItem(this.itemEdition[id]);
+				this.copyDocumentAllId(id, realId);
+				this.copyItemBoxAllId(id, realId);
+				this.copyItemTagAllId(id, realId);
+				this.copyItemCommandAllId(id, realId);
+				this.copyItemProjectAllId(id, realId);
+				this.copyImageAllId(id, realId);
+			} else {
+				await this.updateItem(id, this.itemEdition[id]);
+			}
+			await Promise.all([
+				this.pushDocumentChange(realId),
+				this.pushItemBoxChange(realId),
+				this.pushItemTagChange(realId),
+				this.pushItemCommandChange(realId),
+				this.pushItemProjectChange(realId),
+				this.pushImageChange(realId),
+			]);
+			return realId;
 		},
 
 		getDocumentByInterval: documentResource.getByInterval,
@@ -282,6 +334,11 @@ export const useItemsStore = defineStore("items",{
 		createDocument: documentResource.create,
 		updateDocument: documentResource.update,
 		deleteDocument: documentResource.remove,
+		getAvailableNewDocumentId: documentResource.getAvailableNewId,
+		valideDocumentEditionById: documentResource.valideEditionById,
+		copyDocumentPerId: documentResource.copyPerId,
+		copyDocumentAllId: documentResource.copyAllId,
+		pushDocumentChange: documentResource.pushChange,
 		async downloadDocument(idItem, id) {
 			return await fetchWrapper.image({
 				url: `${baseUrl}/item/${idItem}/document/${id}/download`,
@@ -294,6 +351,11 @@ export const useItemsStore = defineStore("items",{
 		createItemBox: itemBoxResource.create,
 		updateItemBox: itemBoxResource.update,
 		deleteItemBox: itemBoxResource.remove,
+		getAvailableNewItemBoxId: itemBoxResource.getAvailableNewId,
+		valideItemBoxEditionById: itemBoxResource.valideEditionById,
+		copyItemBoxPerId: itemBoxResource.copyPerId,
+		copyItemBoxAllId: itemBoxResource.copyAllId,
+		pushItemBoxChange: itemBoxResource.pushChange,
 
 		getItemTagByInterval: itemTagResource.getByInterval,
 		getItemTagById: itemTagResource.getById,
@@ -301,6 +363,11 @@ export const useItemsStore = defineStore("items",{
 		deleteItemTag: itemTagResource.remove,
 		createItemTagBulk: itemTagResource.createBulk,
 		deleteItemTagBulk: itemTagResource.deleteBulk,
+		getAvailableNewItemTagId: itemTagResource.getAvailableNewId,
+		valideItemTagEditionById: itemTagResource.valideEditionById,
+		copyItemTagPerId: itemTagResource.copyPerId,
+		copyItemTagAllId: itemTagResource.copyAllId,
+		pushItemTagChange: itemTagResource.pushChange,
 
 		getItemCommandByInterval: itemCommandResource.getByInterval,
 		getItemCommandById: itemCommandResource.getById,
@@ -308,6 +375,11 @@ export const useItemsStore = defineStore("items",{
 		updateItemCommand: itemCommandResource.update,
 		deleteItemCommand: itemCommandResource.remove,
 		createItemCommandBulk: itemCommandResource.createBulk,
+		getAvailableNewItemCommandId: itemCommandResource.getAvailableNewId,
+		valideItemCommandEditionById: itemCommandResource.valideEditionById,
+		copyItemCommandPerId: itemCommandResource.copyPerId,
+		copyItemCommandAllId: itemCommandResource.copyAllId,
+		pushItemCommandChange: itemCommandResource.pushChange,
 
 		getItemProjectByInterval: itemProjectResource.getByInterval,
 		getItemProjectById: itemProjectResource.getById,
@@ -315,12 +387,22 @@ export const useItemsStore = defineStore("items",{
 		updateItemProject: itemProjectResource.update,
 		deleteItemProject: itemProjectResource.remove,
 		createItemProjectBulk: itemProjectResource.createBulk,
+		getAvailableNewItemProjectId: itemProjectResource.getAvailableNewId,
+		valideItemProjectEditionById: itemProjectResource.valideEditionById,
+		copyItemProjectPerId: itemProjectResource.copyPerId,
+		copyItemProjectAllId: itemProjectResource.copyAllId,
+		pushItemProjectChange: itemProjectResource.pushChange,
 
 		getImageByInterval: imageResource.getByInterval,
 		getImageById: imageResource.getById,
 		createImage: imageResource.create,
 		updateImage: imageResource.update,
 		deleteImage: imageResource.remove,
+		getAvailableNewImageId: imageResource.getAvailableNewId,
+		valideImageEditionById: imageResource.valideEditionById,
+		copyImagePerId: imageResource.copyPerId,
+		copyImageAllId: imageResource.copyAllId,
+		pushImageChange: imageResource.pushChange,
 		async showImageById(id_item, id_img) {
 			if (this.imagesURL[id_img]) {
 				return;

--- a/electrostoreFRONT/src/stores/projects.store.js
+++ b/electrostoreFRONT/src/stores/projects.store.js
@@ -69,6 +69,8 @@ const commentResource = createNestedResource({
 	stateKey: "comments",
 	countKey: "commentsTotalCount",
 	loadingKey: "commentsLoading",
+	editionKey: "commentEdition",
+	readyKey: "commentsReady",
 	onHydrate: (store, entity, expand) => {
 		if (expand.includes("user")) {
 			const usersStore = useUsersStore();
@@ -82,6 +84,8 @@ const documentResource = createNestedResource({
 	stateKey: "documents",
 	countKey: "documentsTotalCount",
 	loadingKey: "documentsLoading",
+	editionKey: "documentEdition",
+	readyKey: "documentsReady",
 });
 const itemResource = createNestedResource({
 	path: (idProject) => `/project/${idProject}/item`,
@@ -89,6 +93,8 @@ const itemResource = createNestedResource({
 	stateKey: "items",
 	countKey: "itemsTotalCount",
 	loadingKey: "itemsLoading",
+	editionKey: "itemEdition",
+	readyKey: "itemReady",
 	onHydrate: (store, entity, expand) => {
 		if (expand.includes("item")) {
 			const itemsStore = useItemsStore();
@@ -102,6 +108,8 @@ const projectTagProjectResource = createNestedResource({
 	stateKey: "projectTagProject",
 	countKey: "projectTagProjectTotalCount",
 	loadingKey: "projectTagProjectLoading",
+	editionKey: "projectTagProjectEdition",
+	readyKey: "projectTagProjectReady",
 	onHydrate: (store, entity, expand) => {
 		if (expand.includes("project_tag")) {
 			const projectTagsStore = useProjectTagsStore();
@@ -128,21 +136,25 @@ export const useProjectsStore = defineStore("projects",{
 		commentsTotalCount: {},
 		comments: {},
 		commentEdition: {},
+		commentsReady: {},
 
 		documentsLoading: false,
 		documentsTotalCount: {},
 		documents: {},
 		documentEdition: {},
+		documentReady: {},
 
 		itemsLoading: false,
 		itemsTotalCount: {},
 		items: {},
 		itemEdition: {},
+		itemReady: {},
 
 		projectTagProjectLoading: false,
 		projectTagProjectTotalCount: {},
 		projectTagProject: {},
 		projectTagProjectEdition: {},
+		projectTagProjectReady: {},
 
 		statusHistoryTotalCount: {},
 		statusHistoryLoading: false,
@@ -181,9 +193,13 @@ export const useProjectsStore = defineStore("projects",{
 				};
 			}
 			this.commentEdition[id] = {};
+			this.commentReady[id] = {};
 			this.documentEdition[id] = {};
+			this.documentReady[id] = {};
 			this.itemEdition[id] = {};
+			this.itemReady[id] = {};
 			this.projectTagProjectEdition[id] = {};
+			this.projectTagProjectReady[id] = {};
 		},
 		setLoadingEdition(id, loading) {
 			if (!this.projectEdition[id]) {
@@ -194,9 +210,32 @@ export const useProjectsStore = defineStore("projects",{
 		clearEdition(id) {
 			delete this.projectEdition[id];
 			delete this.commentEdition[id];
+			delete this.commentReady[id];
 			delete this.documentEdition[id];
+			delete this.documentReady[id];
 			delete this.itemEdition[id];
+			delete this.itemReady[id];
 			delete this.projectTagProjectEdition[id];
+			delete this.projectTagProjectReady[id];
+		},
+		async saveAllChanges(id) {
+			let realId = id;
+			if (id === "new") {
+				realId = await this.createProject(this.projectEdition[id]);
+				this.copyCommentAllId(id, realId);
+				this.copyDocumentAllId(id, realId);
+				this.copyItemAllId(id, realId);
+				this.copyProjectTagProjectAllId(id, realId);
+			} else {
+				await this.updateProject(realId, this.projectEdition[id]);
+			}
+			await Promise.all([
+				this.pushCommentChange(realId),
+				this.pushDocumentChange(realId),
+				this.pushItemChange(realId),
+				this.pushProjectTagProjectChange(realId),
+			]);
+			return realId;
 		},
 
 		getCommentByInterval: commentResource.getByInterval,
@@ -204,12 +243,22 @@ export const useProjectsStore = defineStore("projects",{
 		createComment: commentResource.create,
 		updateComment: commentResource.update,
 		deleteComment: commentResource.remove,
+		getAvailableNewCommentId: commentResource.getAvailableNewId,
+		valideCommentEditionById: commentResource.valideEditionById,
+		copyCommentPerId: commentResource.copyPerId,
+		copyCommentAllId: commentResource.copyAllId,
+		pushCommentChange: commentResource.pushChange,
 
 		getDocumentByInterval: documentResource.getByInterval,
 		getDocumentById: documentResource.getById,
 		createDocument: documentResource.create,
 		updateDocument: documentResource.update,
 		deleteDocument: documentResource.remove,
+		getAvailableNewDocumentId: documentResource.getAvailableNewId,
+		valideDocumentEditionById: documentResource.valideEditionById,
+		copyDocumentPerId: documentResource.copyPerId,
+		copyDocumentAllId: documentResource.copyAllId,
+		pushDocumentChange: documentResource.pushChange,
 		async downloadDocument(idProject, id) {
 			return await fetchWrapper.image({
 				url: `${baseUrl}/project/${idProject}/document/${id}/download`,
@@ -223,6 +272,11 @@ export const useProjectsStore = defineStore("projects",{
 		updateItem: itemResource.update,
 		deleteItem: itemResource.remove,
 		createItemBulk: itemResource.createBulk,
+		getAvailableNewItemId: itemResource.getAvailableNewId,
+		valideItemEditionById: itemResource.valideEditionById,
+		copyItemPerId: itemResource.copyPerId,
+		copyItemAllId: itemResource.copyAllId,
+		pushItemChange: itemResource.pushChange,
 		
 		getProjectTagProjectByInterval: projectTagProjectResource.getByInterval,
 		getProjectTagProjectById: projectTagProjectResource.getById,
@@ -230,6 +284,11 @@ export const useProjectsStore = defineStore("projects",{
 		deleteProjectTagProject: projectTagProjectResource.remove,
 		createProjectTagProjectBulk: projectTagProjectResource.createBulk,
 		deleteProjectTagProjectBulk: projectTagProjectResource.removeBulk,
+		getAvailableNewProjectTagProjectId: projectTagProjectResource.getAvailableNewId,
+		valideProjectTagProjectEditionById: projectTagProjectResource.valideEditionById,
+		copyProjectTagProjectPerId: projectTagProjectResource.copyPerId,
+		copyProjectTagProjectAllId: projectTagProjectResource.copyAllId,
+		pushProjectTagProjectChange: projectTagProjectResource.pushChange,
 
 		getStatusHistoryByInterval: statusHistoryResource.getByInterval,
 		getStatusHistoryById: statusHistoryResource.getById,

--- a/electrostoreFRONT/src/stores/projecttags.store.js
+++ b/electrostoreFRONT/src/stores/projecttags.store.js
@@ -1,8 +1,9 @@
 import { defineStore } from "pinia";
 
-import { fetchWrapper, buildQuery, createMainResource, createNestedResource } from "@/helpers";
+import { createMainResource, createNestedResource } from "@/helpers";
 
 import { useProjectsStore } from "@/stores";
+import { readonly } from "vue";
 
 const baseUrl = `${import.meta.env.VITE_API_URL}`;
 
@@ -41,6 +42,8 @@ const projectTagProjectResource = createNestedResource({
 	stateKey: "projectTagsProject",
 	countKey: "projectTagsProjectTotalCount",
 	loadingKey: "projectTagsProjectLoading",
+	editionKey: "projectTagProjectEdition",
+	readyKey: "projectTagProjectReady",
 	onHydrate: (store, idProjectTag, entity, expand) => {
 		if (expand.includes("project")) {
 			const projectsStore = useProjectsStore();
@@ -60,6 +63,7 @@ export const useProjectTagsStore = defineStore("projectTags",{
 		projectTagsProjectTotalCount: {},
 		projectTagsProject: {},
 		projectTagProjectEdition: {},
+		projectTagProjectReady: {},
 	}),
 	actions: {
 		getProjectTagByList: projectTagResource.getByList,
@@ -101,6 +105,18 @@ export const useProjectTagsStore = defineStore("projectTags",{
 		clearEdition(id) {
 			delete this.projectTagEdition[id];
 			delete this.projectTagProjectEdition[id];
+			delete this.projectTagProjectReady[id];
+		},
+		async saveAllChanges(id) {
+			let realId = id;
+			if (id === "new") {
+				realId = await this.createProjectTag(this.projectTagEdition[id]);
+				this.copyProjectTagProjectAllId(id, realId);
+			} else {
+				await this.updateProjectTag(realId, this.projectTagEdition[id]);
+			}
+			await this.getProjectTagById(realId, ["project_tags"]);
+			return realId;
 		},
 
 		getProjectTagProjectByInterval: projectTagProjectResource.getByInterval,
@@ -109,5 +125,10 @@ export const useProjectTagsStore = defineStore("projectTags",{
 		deleteProjectTagProject: projectTagProjectResource.remove,
 		createProjectTagProjectBulk: projectTagProjectResource.createBulk,
 		deleteProjectTagProjectBulk: projectTagProjectResource.removeBulk,
+		getAvailableNewProjectTagProjectId: projectTagProjectResource.getAvailableNewId,
+		valideProjectTagProjectEditionById: projectTagProjectResource.valideEditionById,
+		copyProjectTagProjectPerId: projectTagProjectResource.copyPerId,
+		copyProjectTagProjectAllId: projectTagProjectResource.copyAllId,
+		pushProjectTagProjectChange: projectTagProjectResource.pushChange,
 	},
 });

--- a/electrostoreFRONT/src/stores/stores.store.js
+++ b/electrostoreFRONT/src/stores/stores.store.js
@@ -80,6 +80,8 @@ const boxResource = createNestedResource({
 	stateKey: "boxs",
 	countKey: "boxsTotalCount",
 	loadingKey: "boxsLoading",
+	editionKey: "boxEdition",
+	readyKey: "boxReady",
 	onHydrate: (store, idStore, entity, expand) => {
 		hydrateBox(store, idStore, entity.id_box, entity, expand);
 	},
@@ -90,6 +92,8 @@ const ledResource = createNestedResource({
 	stateKey: "leds",
 	countKey: "ledsTotalCount",
 	loadingKey: "ledsLoading",
+	editionKey: "ledEdition",
+	readyKey: "ledReady",
 });
 const storeTagResource = createNestedResource({
 	path: (idStore) => `/store/${idStore}/store_tag`,
@@ -97,6 +101,8 @@ const storeTagResource = createNestedResource({
 	stateKey: "storeTags",
 	countKey: "storeTagsTotalCount",
 	loadingKey: "storeTagsLoading",
+	editionKey: "storeTagEdition",
+	readyKey: "storeTagReady",
 	onHydrate: (store, idStore, entity, expand) => {
 		if (expand.includes("tag")) {
 			const tagsStore = useTagsStore();
@@ -116,26 +122,31 @@ export const useStoresStore = defineStore("stores",{
 		boxsTotalCount: {},
 		boxs: {},
 		boxEdition: {},
+		boxReady: {},
 
 		ledsLoading: false,
 		ledsTotalCount: {},
 		leds: {},
 		ledEdition: {},
+		ledReady: {},
 
 		storeTagsLoading: false,
 		storeTagsTotalCount: {},
 		storeTags: {},
 		storeTagEdition: {},
+		storeTagReady: {},
 
 		boxItemsLoading: false,
 		boxItemsTotalCount: {},
 		boxItems: {},
 		boxItemEdition: {},
+		boxItemReady: {},
 
 		boxTagsLoading: false,
 		boxTagsTotalCount: {},
 		boxTags: {},
 		boxTagEdition: {},
+		boxTagReady: {},
 	}),
 	actions: {
 		getStoreByList: storeResource.getByList,
@@ -183,13 +194,21 @@ export const useStoresStore = defineStore("stores",{
 					mqtt_last_seen_store: this.stores[id].mqtt_last_seen_store,
 				};
 				this.ledEdition[id] = { ...this.leds[id] };
+				this.ledReady[id] = {};
 				this.boxEdition[id] = { ...this.boxs[id] };
+				this.boxReady[id] = {};
+				this.storeTagEdition[id] = { ...this.storeTags[id] };
+				this.storeTagReady[id] = {};
 			} else {
 				this.storeEdition[id] = {
 					loading: false,
 				};
 				this.ledEdition[id] = {};
+				this.ledReady[id] = {};
 				this.boxEdition[id] = {};
+				this.boxReady[id] = {};
+				this.storeTagEdition[id] = {};
+				this.storeTagReady[id] = {};
 			}
 		},
 		setLoadingEdition(id, loading) {
@@ -199,11 +218,29 @@ export const useStoresStore = defineStore("stores",{
 			this.storeEdition[id].loading = loading;
 		},
 		clearEdition(id) {
-			if (this.storeEdition && this.storeEdition[id]) {
-				delete this.storeEdition[id];
-				delete this.ledEdition[id];
-				delete this.boxEdition[id];
+			delete this.storeEdition[id];
+			delete this.ledEdition[id];
+			delete this.ledReady[id];
+			delete this.boxEdition[id];
+			delete this.boxReady[id];
+			delete this.storeTagEdition[id];
+			delete this.storeTagReady[id];
+		},
+		async saveAllChanges(id) {
+			let realId = id;
+			const payload = {
+				store: this.storeEdition[id],
+				leds: Object.values(this.ledEdition[id] ?? {}),
+				boxs: Object.values(this.boxEdition[id] ?? {}),
+			};
+			if (id === "new") {
+				realId = await this.createStoreComplete(id, payload);
+				this.copyTagStoreAllId(id, realId);
+			} else {
+				await this.updateStoreComplete(id, payload);
 			}
+			await this.pushTagStoreChange(realId);
+			return realId;
 		},
 
 		getBoxByInterval: boxResource.getByInterval,
@@ -214,6 +251,11 @@ export const useStoresStore = defineStore("stores",{
 		createBoxBulk: boxResource.createBulk,
 		updateBoxBulk: boxResource.updateBulk,
 		deleteBoxBulk: boxResource.removeBulk,
+		getAvailableNewBoxId: boxResource.getAvailableNewId,
+		valideBoxEditionById: boxResource.valideEditionById,
+		copyBoxPerId: boxResource.copyPerId,
+		copyBoxAllId: boxResource.copyAllId,
+		pushBoxChange: boxResource.pushChange,
 		async showBoxById(idStore, id, params) {
 			await fetchWrapper.post({
 				url: `${baseUrl}/store/${idStore}/box/${id}/show`,
@@ -230,6 +272,11 @@ export const useStoresStore = defineStore("stores",{
 		createLedBulk: ledResource.createBulk,
 		updateLedBulk: ledResource.updateBulk,
 		deleteLedBulk: ledResource.removeBulk,
+		getAvailableNewLedId: ledResource.getAvailableNewId,
+		valideLedEditionById: ledResource.valideEditionById,
+		copyLedPerId: ledResource.copyPerId,
+		copyLedAllId: ledResource.copyAllId,
+		pushLedChange: ledResource.pushChange,
 		async showLedById(idStore, id, params) {
 			await fetchWrapper.post({
 				url: `${baseUrl}/store/${idStore}/led/${id}/show`,
@@ -244,6 +291,11 @@ export const useStoresStore = defineStore("stores",{
 		deleteTagStore: storeTagResource.remove,
 		createTagStoreBulk: storeTagResource.createBulk,
 		deleteTagStoreBulk: storeTagResource.removeBulk,
+		getAvailableNewTagStoreId: storeTagResource.getAvailableNewId,
+		valideTagStoreEditionById: storeTagResource.valideEditionById,
+		copyTagStorePerId: storeTagResource.copyPerId,
+		copyTagStoreAllId: storeTagResource.copyAllId,
+		pushTagStoreChange: storeTagResource.pushChange,
 
 		async getBoxItemByInterval(idStore, idBox, limit = 100, offset = 0, expand = [], filter = "", sort = "", clear = false) {
 			if (!this.boxItems[idBox] || clear) {

--- a/electrostoreFRONT/src/stores/tags.store.js
+++ b/electrostoreFRONT/src/stores/tags.store.js
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 
-import { fetchWrapper, buildQuery, createMainResource, createNestedResource } from "@/helpers";
+import { createMainResource, createNestedResource } from "@/helpers";
 
 import { useStoresStore, useItemsStore } from "@/stores";
 
@@ -55,6 +55,8 @@ const tagStoreResource = createNestedResource({
 	stateKey: "tagsStore",
 	countKey: "tagsStoreTotalCount",
 	loadingKey: "tagsStoreLoading",
+	editionKey: "tagStoreEdition",
+	readyKey: "tagStoreReady",
 	onHydrate: (store, idTag, entity, expand) => {
 		if (expand.includes("store")) {
 			const storesStore = useStoresStore();
@@ -68,6 +70,8 @@ const tagBoxResource = createNestedResource({
 	stateKey: "tagsBox",
 	countKey: "tagsBoxTotalCount",
 	loadingKey: "tagsBoxLoading",
+	editionKey: "tagBoxEdition",
+	readyKey: "tagBoxReady",
 	onHydrate: (store, idTag, entity, expand) => {
 		if (expand.includes("box")) {
 			const storesStore = useStoresStore();
@@ -82,6 +86,8 @@ const tagItemResource = createNestedResource({
 	stateKey: "tagsItem",
 	countKey: "tagsItemTotalCount",
 	loadingKey: "tagsItemLoading",
+	editionKey: "tagItemEdition",
+	readyKey: "tagItemReady",
 	onHydrate: (store, idTag, entity, expand) => {
 		if (expand.includes("item")) {
 			const itemsStore = useItemsStore();
@@ -101,16 +107,19 @@ export const useTagsStore = defineStore("tags",{
 		tagsStoreTotalCount: {},
 		tagsStore: {},
 		tagStoreEdition: {},
+		tagStoreReady: {},
 
 		tagsBoxLoading: false,
 		tagsBoxTotalCount: {},
 		tagsBox: {},
 		tagBoxEdition: {},
+		tagBoxReady: {},
 
 		tagsItemLoading: false,
 		tagsItemTotalCount: {},
 		tagsItem: {},
 		tagItemEdition: {},
+		tagItemReady: {},
 	}),
 	actions: {
 		getTagByList: tagResource.getByList,
@@ -142,8 +151,11 @@ export const useTagsStore = defineStore("tags",{
 				};
 			}
 			this.tagItemEdition[id] = {};
+			this.tagItemReady[id] = {};
 			this.tagStoreEdition[id] = {};
+			this.tagStoreReady[id] = {};
 			this.tagBoxEdition[id] = {};
+			this.tagBoxReady[id] = {};
 		},
 		setLoadingEdition(id, loading) {
 			if (!this.tagEdition[id]) {
@@ -154,8 +166,28 @@ export const useTagsStore = defineStore("tags",{
 		clearEdition(id) {
 			delete this.tagEdition[id];
 			delete this.tagItemEdition[id];
+			delete this.tagItemReady[id];
 			delete this.tagStoreEdition[id];
+			delete this.tagStoreReady[id];
 			delete this.tagBoxEdition[id];
+			delete this.tagBoxReady[id];
+		},
+		async saveAllChanges(id) {
+			let realId = id;
+			if (id === "new") {
+				realId = await this.createTag(this.tagEdition[id]);
+				this.copyTagStoreAllId(id, realId);
+				this.copyTagBoxAllId(id, realId);
+				this.copyTagItemAllId(id, realId);
+			} else {
+				await this.updateTag(id, this.tagEdition[id]);
+			}
+			await Promise.all([
+				this.pushTagStoreChange(realId),
+				this.pushTagBoxChange(realId),
+				this.pushTagItemChange(realId),
+			]);
+			return realId;
 		},
 
 		getTagStoreByInterval: tagStoreResource.getByInterval,
@@ -164,6 +196,11 @@ export const useTagsStore = defineStore("tags",{
 		deleteTagStore: tagStoreResource.remove,
 		createTagStoreBulk: tagStoreResource.createBulk,
 		deleteTagStoreBulk: tagStoreResource.removeBulk,
+		getAvailableNewTagStoreId: tagStoreResource.getAvailableNewId,
+		valideTagStoreEditionById: tagStoreResource.valideEditionById,
+		copyTagStorePerId: tagStoreResource.copyPerId,
+		copyTagStoreAllId: tagStoreResource.copyAllId,
+		pushTagStoreChange: tagStoreResource.pushChange,
 
 		getTagBoxByInterval: tagBoxResource.getByInterval,
 		getTagBoxById: tagBoxResource.getById,
@@ -171,6 +208,11 @@ export const useTagsStore = defineStore("tags",{
 		deleteTagBox: tagBoxResource.remove,
 		createTagBoxBulk: tagBoxResource.createBulk,
 		deleteTagBoxBulk: tagBoxResource.removeBulk,
+		getAvailableNewTagBoxId: tagBoxResource.getAvailableNewId,
+		valideTagBoxEditionById: tagBoxResource.valideEditionById,
+		copyTagBoxPerId: tagBoxResource.copyPerId,
+		copyTagBoxAllId: tagBoxResource.copyAllId,
+		pushTagBoxChange: tagBoxResource.pushChange,
 
 		getTagItemByInterval: tagItemResource.getByInterval,
 		getTagItemById: tagItemResource.getById,
@@ -178,5 +220,10 @@ export const useTagsStore = defineStore("tags",{
 		deleteTagItem: tagItemResource.remove,
 		createTagItemBulk: tagItemResource.createBulk,
 		deleteTagItemBulk: tagItemResource.removeBulk,
+		getAvailableNewTagItemId: tagItemResource.getAvailableNewId,
+		valideTagItemEditionById: tagItemResource.valideEditionById,
+		copyTagItemPerId: tagItemResource.copyPerId,
+		copyTagItemAllId: tagItemResource.copyAllId,
+		pushTagItemChange: tagItemResource.pushChange,
 	},
 });

--- a/electrostoreFRONT/src/stores/users.store.js
+++ b/electrostoreFRONT/src/stores/users.store.js
@@ -1,6 +1,6 @@
 import { defineStore } from "pinia";
 
-import { fetchWrapper, buildQuery, createMainResource, createNestedResource } from "@/helpers";
+import { fetchWrapper, createMainResource, createNestedResource } from "@/helpers";
 
 import { useCommandsStore, useProjectsStore } from "@/stores";
 
@@ -60,6 +60,8 @@ const projectCommentResource = createNestedResource({
 	stateKey: "projectsComment",
 	countKey: "projectsCommentTotalCount",
 	loadingKey: "projectsCommentLoading",
+	editionKey: "projectCommentEdition",
+	readyKey: "projectCommentReady",
 	onHydrate: (store, idUser, entity, expand) => {
 		if (expand.includes("project")) {
 			const projectStore = useProjectsStore();
@@ -73,6 +75,8 @@ const commandCommentResource = createNestedResource({
 	stateKey: "commandsComment",
 	countKey: "commandsCommentTotalCount",
 	loadingKey: "commandsCommentLoading",
+	editionKey: "commandCommentEdition",
+	readyKey: "commandCommentReady",
 	onHydrate: (store, idUser, entity, expand) => {
 		if (expand.includes("command")) {
 			const commandStore = useCommandsStore();
@@ -106,11 +110,13 @@ export const useUsersStore = defineStore("users",{
 		projectsCommentTotalCount: {},
 		projectsComment: {},
 		projectCommentEdition: {},
+		projectCommentReady: {},
 
 		commandsCommentLoading: false,
 		commandsCommentTotalCount: {},
 		commandsComment: {},
 		commandCommentEdition: {},
+		commandCommentReady: {},
 
 		tokensLoading: false,
 		tokensTotalCount: {},
@@ -156,7 +162,9 @@ export const useUsersStore = defineStore("users",{
 				};
 			}
 			this.projectCommentEdition[id] = {};
+			this.projectCommentReady[id] = {};
 			this.commandCommentEdition[id] = {};
+			this.commandCommentReady[id] = {};
 			this.tokensEdition[id] = {};
 			this.pushSubscriptionsEdition[id] = {};
 		},
@@ -169,9 +177,26 @@ export const useUsersStore = defineStore("users",{
 		clearEdition(id) {
 			delete this.userEdition[id];
 			delete this.projectCommentEdition[id];
+			delete this.projectCommentReady[id];
 			delete this.commandCommentEdition[id];
+			delete this.commandCommentReady[id];
 			delete this.tokensEdition[id];
 			delete this.pushSubscriptionsEdition[id];
+		},
+		async saveAllChanges(id) {
+			let realId = id;
+			if (id === "new") {
+				realId = await this.createUser(this.userEdition[id]);
+				this.copyProjectCommentAllId(id, realId);
+				this.copyCommandCommentAllId(id, realId);
+			} else {
+				await this.updateUser(id, this.userEdition[id]);
+			}
+			await Promise.all([
+				this.pushProjectCommentChange(realId),
+				this.pushCommandCommentChange(realId),
+			]);
+			return realId;
 		},
 
 		getProjectCommentByInterval: projectCommentResource.getByInterval,
@@ -179,17 +204,27 @@ export const useUsersStore = defineStore("users",{
 		createProjectComment: projectCommentResource.create,
 		updateProjectComment: projectCommentResource.update,
 		deleteProjectComment: projectCommentResource.remove,
+		getAvailableNewProjectCommentId: projectCommentResource.getAvailableNewId,
+		valideProjectCommentEditionById: projectCommentResource.valideEditionById,
+		copyProjectCommentPerId: projectCommentResource.copyPerId,
+		copyProjectCommentAllId: projectCommentResource.copyAllId,
+		pushProjectCommentChange: projectCommentResource.pushChange,
 
 		getCommandCommentByInterval: commandCommentResource.getByInterval,
 		getCommandCommentById: commandCommentResource.getById,
 		createCommandComment: commandCommentResource.create,
 		updateCommandComment: commandCommentResource.update,
 		deleteCommandComment: commandCommentResource.remove,
+		getAvailableNewCommandCommentId: commandCommentResource.getAvailableNewId,
+		valideCommandCommentEditionById: commandCommentResource.valideEditionById,
+		copyCommandCommentPerId: commandCommentResource.copyPerId,
+		copyCommandCommentAllId: commandCommentResource.copyAllId,
+		pushCommandCommentChange: commandCommentResource.pushChange,
 
 		getTokenByInterval: tokenResource.getByInterval,
 		getTokenById: tokenResource.getById,
 		updateToken: tokenResource.update,
-		
+
 		getPushSubscriptionsByInterval: pushSubscriptionResource.getByInterval,
 		createPushSubscription: pushSubscriptionResource.create,
 		deletePushSubscription: pushSubscriptionResource.remove,


### PR DESCRIPTION
Extend `createNestedResource` with per-parent draft/ready tracking, temp ID helpers, copy utilities, and batched `pushChange` support. Wire those capabilities into the Pinia stores so nested comments, documents, tags, items, boxes, and related records can be created or updated together through new `saveAllChanges` flows, while also cleaning up a few unused imports.