### PR TITLE
feat: Add store LED position modes

### DIFF
--- a/electrostoreAPI/DTO/ItemDto.cs
+++ b/electrostoreAPI/DTO/ItemDto.cs
@@ -64,5 +64,6 @@ public record UpdateItemDto
     [MaxLength(Constants.MaxDescriptionLength, ErrorMessage = "{0} cannot exceed {1} characters.")]
     public string? description_item { get; init; }
 
+    public bool? unset_img_item { get; init; }
     public int? id_img { get; init; }
 }

--- a/electrostoreAPI/DTO/StoreDto.cs
+++ b/electrostoreAPI/DTO/StoreDto.cs
@@ -1,3 +1,4 @@
+using ElectrostoreAPI.Enums;
 using ElectrostoreAPI.Validators;
 using System.ComponentModel.DataAnnotations;
 
@@ -9,6 +10,7 @@ public record ReadStoreDto
     public required string name_store { get; init; }
     public int xlength_store { get; init; }
     public int ylength_store { get; init; }
+    public StorePositionMode position_mode_store { get; init; }
     public required string mqtt_name_store { get; init; }
     public string? mqtt_password_store { get; init; }
     public DateTime? mqtt_last_seen_store { get; init; }
@@ -40,6 +42,9 @@ public record CreateStoreDto
     [Range(1, int.MaxValue, ErrorMessage = "{0} must be greater than or equal to {1}, and less than or equal to {2}.")]
     public required int ylength_store { get; init; }
 
+    [Range(0, (int)StorePositionMode.Border, ErrorMessage = "{0} must be a valid position mode, between {1} and {2}.")]
+    public StorePositionMode position_mode_store { get; init; } = StorePositionMode.Grid;
+
     [Required(ErrorMessage = "{0} is required.")]
     [MaxLength(Constants.MaxNameLength, ErrorMessage = "{0} cannot exceed {1} characters.")]
     public required string mqtt_name_store { get; init; }
@@ -56,6 +61,9 @@ public record UpdateStoreDto
 
     [Range(1, int.MaxValue, ErrorMessage = "{0} must be greater than or equal to {1}, and less than or equal to {2}.")]
     public int? ylength_store { get; init; }
+
+    [Range(0, (int)StorePositionMode.Border, ErrorMessage = "{0} must be a valid position mode, between {1} and {2}.")]
+    public StorePositionMode? position_mode_store { get; init; }
 
     [MaxLength(Constants.MaxNameLength, ErrorMessage = "{0} cannot exceed {1} characters.")]
     [OptionalNotEmpty(ErrorMessage = "{0} cannot be empty or whitespace.")]

--- a/electrostoreAPI/Enums/LedBorderSide.cs
+++ b/electrostoreAPI/Enums/LedBorderSide.cs
@@ -1,0 +1,10 @@
+
+namespace ElectrostoreAPI.Enums;
+
+public enum LedBorderSide
+{
+    Left,
+    Right,
+    Top,
+    Bottom
+}

--- a/electrostoreAPI/Enums/StorePositionMode.cs
+++ b/electrostoreAPI/Enums/StorePositionMode.cs
@@ -1,0 +1,8 @@
+
+namespace ElectrostoreAPI.Enums;
+
+public enum StorePositionMode
+{
+    Grid,
+    Border
+}

--- a/electrostoreAPI/Migrations/20260819074628_AddStorePositionMode.Designer.cs
+++ b/electrostoreAPI/Migrations/20260819074628_AddStorePositionMode.Designer.cs
@@ -4,16 +4,19 @@ using ElectrostoreAPI;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace ElectrostoreAPI.Migrations
+namespace electrostoreAPI.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260819074628_AddStorePositionMode")]
+    partial class AddStorePositionMode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/electrostoreAPI/Migrations/20260819074628_AddStorePositionMode.cs
+++ b/electrostoreAPI/Migrations/20260819074628_AddStorePositionMode.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace electrostoreAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStorePositionMode : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "position_mode_store",
+                table: "Stores",
+                type: "int",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "position_mode_store",
+                table: "Stores");
+        }
+    }
+}

--- a/electrostoreAPI/Models/Stores.cs
+++ b/electrostoreAPI/Models/Stores.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using ElectrostoreAPI.Dto;
+using ElectrostoreAPI.Enums;
 
 namespace ElectrostoreAPI.Models;
 
@@ -16,6 +17,8 @@ public class Stores : BaseEntity
     public int xlength_store { get; set; }
 
     public int ylength_store { get; set; }
+
+    public StorePositionMode position_mode_store { get; set; } = StorePositionMode.Grid;
 
     [MaxLength(Constants.MaxNameLength)]
     public required string mqtt_name_store { get; set; }

--- a/electrostoreAPI/Services/ItemService/ItemService.cs
+++ b/electrostoreAPI/Services/ItemService/ItemService.cs
@@ -199,7 +199,11 @@ public class ItemService : IItemService
         {
             itemToUpdate.description_item = itemDto.description_item;
         }
-        if (itemDto.id_img is not null)
+        if (itemDto.unset_img_item is true)
+        {
+            itemToUpdate.id_img = null;
+        }
+        else if (itemDto.id_img is not null)
         {
             var img = await _context.Imgs.FindAsync(itemDto.id_img);
             if ((img is null) || (id != img.id_item))

--- a/electrostoreAPI/Services/LedService/LedService.cs
+++ b/electrostoreAPI/Services/LedService/LedService.cs
@@ -287,26 +287,29 @@ public class LedService : ILedService
 
     public async Task ShowLedsByBox(int storeId, int boxId, int redColor, int greenColor, int blueColor, int timeshow, int animation)
     {
-        // check if the store exists
-        if (!await _context.Stores.AnyAsync(s => s.id_store == storeId))
-        {
-            throw new KeyNotFoundException($"Store with id '{storeId}' not found");
-        }
+        var store = await _context.Stores.FindAsync(storeId) ?? throw new KeyNotFoundException($"Store with id '{storeId}' not found");
         // check if the box exists
         if (!await _context.Boxs.AnyAsync(b => b.id_box == boxId && b.id_store == storeId))
         {
             throw new KeyNotFoundException($"Box with id '{boxId}' not found in store with id '{storeId}'");
         }
-        var ledsDB = await _context.Leds
+        var ledsQuery = _context.Leds
             .Join(_context.Boxs,
                 led => new { led.id_store },
                 box => new { box.id_store },
                 (led, box) => new { led, box })
-            .Where(x => x.box.id_box == boxId && x.led.id_store == storeId &&
-                   x.led.x_led >= x.box.xstart_box && x.led.x_led <= x.box.xend_box &&
-                     x.led.y_led >= x.box.ystart_box && x.led.y_led <= x.box.yend_box)
-            .Select(x => x.led)
-            .ToListAsync();
+            .Where(x => x.box.id_box == boxId && x.led.id_store == storeId);
+        ledsQuery = store.position_mode_store == StorePositionMode.Border
+            // border mode: leds sit along a store edge and light up when they share the box's level on that edge's axis
+            ? ledsQuery.Where(x =>
+                ((x.led.y_led == (int)LedBorderSide.Left || x.led.y_led == (int)LedBorderSide.Right) &&
+                    x.led.x_led >= x.box.ystart_box && x.led.x_led <= x.box.yend_box) ||
+                ((x.led.y_led == (int)LedBorderSide.Top || x.led.y_led == (int)LedBorderSide.Bottom) &&
+                    x.led.x_led >= x.box.xstart_box && x.led.x_led <= x.box.xend_box))
+            : ledsQuery.Where(x =>
+                x.led.x_led >= x.box.xstart_box && x.led.x_led <= x.box.xend_box &&
+                x.led.y_led >= x.box.ystart_box && x.led.y_led <= x.box.yend_box);
+        var ledsDB = await ledsQuery.Select(x => x.led).ToListAsync();
         if (ledsDB.Count == 0)
         {
             throw new KeyNotFoundException($"No leds found in store with id '{storeId}' and box with id '{boxId}'");
@@ -315,7 +318,6 @@ public class LedService : ILedService
         {
             throw new NotImplementedException("MQTT client is not connected");
         }
-        var store = await _context.Stores.FindAsync(storeId) ?? throw new KeyNotFoundException($"Store with id '{storeId}' not found");
         var topic = "electrostore/" + store.mqtt_name_store + "/leds";
 
         // sent led 10 per 10

--- a/electrostoreAPI/Services/ValidateStoreService/ValidateStoreService.cs
+++ b/electrostoreAPI/Services/ValidateStoreService/ValidateStoreService.cs
@@ -1,4 +1,5 @@
 using ElectrostoreAPI.Dto;
+using ElectrostoreAPI.Enums;
 using ElectrostoreAPI.Models;
 using Microsoft.EntityFrameworkCore;
 
@@ -14,9 +15,24 @@ public class ValidateStoreService : IValidateStoreService
         _context = context;
     }
 
+    private static bool IsLedPositionValid(Leds led, Stores store)
+    {
+        if (store.position_mode_store == StorePositionMode.Border)
+        {
+            if (!Enum.IsDefined(typeof(LedBorderSide), led.y_led))
+            {
+                return false;
+            }
+            var side = (LedBorderSide)led.y_led;
+            var maxPosition = side is LedBorderSide.Left or LedBorderSide.Right ? store.ylength_store : store.xlength_store;
+            return led.x_led < maxPosition;
+        }
+        return led.x_led < store.xlength_store && led.y_led < store.ylength_store;
+    }
+
     public void ValidateLedPosition(Leds led, Stores store)
     {
-        if (led.x_led >= store.xlength_store || led.y_led >= store.ylength_store)
+        if (!IsLedPositionValid(led, store))
         {
             throw new ArgumentException("Led position is out of store bounds");
         }
@@ -47,6 +63,10 @@ public class ValidateStoreService : IValidateStoreService
         if (storeDto.ylength_store is not null)
         {
             storeToUpdate.ylength_store = storeDto.ylength_store.Value;
+        }
+        if (storeDto.position_mode_store is not null)
+        {
+            storeToUpdate.position_mode_store = storeDto.position_mode_store.Value;
         }
         if (storeDto.mqtt_name_store is not null)
         {
@@ -105,10 +125,11 @@ public class ValidateStoreService : IValidateStoreService
         {
             throw new ArgumentException("you can't reduce the store size, a box will be out of store bounds");
         }
-        // check if a led in the store is outside of the store size
-        if (await _context.Leds.AnyAsync(l => l.id_store == storeToUpdate.id_store && (l.x_led > storeToUpdate.xlength_store || l.y_led > storeToUpdate.ylength_store)))
+        // check if a led in the store is outside of the store size, or invalid for the (possibly new) position mode
+        var storeLeds = await _context.Leds.Where(l => l.id_store == storeToUpdate.id_store).ToListAsync();
+        if (storeLeds.Any(l => !IsLedPositionValid(l, storeToUpdate)))
         {
-            throw new ArgumentException("you can't reduce the store size, a led will be out of store bounds");
+            throw new ArgumentException("you can't apply this change, a led will be out of store bounds or invalid for the store's position mode");
         }
     }
 


### PR DESCRIPTION
This pull request introduces a new "position mode" for stores, allowing them to operate in either a grid or border layout, and updates related logic, validation, and data models accordingly.
Additionally, it adds the ability to unset an item's image and includes new enums to support these features.