### PR TITLE
refactor: Standardize DTO properties to snake_case

### DIFF
--- a/electrostoreAPI/Controllers/CommandDocumentController.cs
+++ b/electrostoreAPI/Controllers/CommandDocumentController.cs
@@ -48,13 +48,13 @@ namespace ElectrostoreAPI.Controllers
         {
             var commandDocument = await _commandDocumentService.GetCommandDocumentById(id_commandDocument, id_command);
             var result = await _fileService.GetFile(commandDocument.url_command_document);
-            if (result.Success && result.FileStream != null)
+            if (result.success && result.file_stream != null)
             {
-                return File(result.FileStream, result.MimeType, commandDocument.name_command_document);
+                return File(result.file_stream, result.mime_type, commandDocument.name_command_document);
             }
             else
             {
-                return NotFound(result.ErrorMessage);
+                return NotFound(result.error_message);
             }
         }
 

--- a/electrostoreAPI/Controllers/ItemController.cs
+++ b/electrostoreAPI/Controllers/ItemController.cs
@@ -79,13 +79,13 @@ namespace ElectrostoreAPI.Controllers
                 return NotFound();
             }
             var result = await _fileService.GetFile(item.url_picture_item);
-            if (result.Success && result.FileStream != null)
+            if (result.success && result.file_stream != null)
             {
-                return File(result.FileStream, result.MimeType);
+                return File(result.file_stream, result.mime_type);
             }
             else
             {
-                return NotFound(result.ErrorMessage);
+                return NotFound(result.error_message);
             }
         }
 
@@ -99,13 +99,13 @@ namespace ElectrostoreAPI.Controllers
                 return NotFound();
             }
             var result = await _fileService.GetFile(item.url_thumbnail_item);
-            if (result.Success && result.FileStream != null)
+            if (result.success && result.file_stream != null)
             {
-                return File(result.FileStream, result.MimeType);
+                return File(result.file_stream, result.mime_type);
             }
             else
             {
-                return NotFound(result.ErrorMessage);
+                return NotFound(result.error_message);
             }
         }
     }

--- a/electrostoreAPI/Controllers/ItemDocumentController.cs
+++ b/electrostoreAPI/Controllers/ItemDocumentController.cs
@@ -48,13 +48,13 @@ namespace ElectrostoreAPI.Controllers
         {
             var itemDocument = await _itemDocumentService.GetItemDocumentById(id_itemDocument, id_item);
             var result = await _fileService.GetFile(itemDocument.url_item_document);
-            if (result.Success && result.FileStream != null)
+            if (result.success && result.file_stream != null)
             {
-                return File(result.FileStream, result.MimeType, itemDocument.name_item_document);
+                return File(result.file_stream, result.mime_type, itemDocument.name_item_document);
             }
             else
             {
-                return NotFound(result.ErrorMessage);
+                return NotFound(result.error_message);
             }
         }
 

--- a/electrostoreAPI/Controllers/ProjectDocumentController.cs
+++ b/electrostoreAPI/Controllers/ProjectDocumentController.cs
@@ -48,13 +48,13 @@ namespace ElectrostoreAPI.Controllers
         {
             var projectDocument = await _projectDocumentService.GetProjectDocumentById(id_project_document, id_project);
             var result = await _fileService.GetFile(projectDocument.url_project_document);
-            if (result.Success && result.FileStream != null)
+            if (result.success && result.file_stream != null)
             {
-                return File(result.FileStream, result.MimeType, projectDocument.name_project_document);
+                return File(result.file_stream, result.mime_type, projectDocument.name_project_document);
             }
             else
             {
-                return NotFound(result.ErrorMessage);
+                return NotFound(result.error_message);
             }
         }
 

--- a/electrostoreAPI/Controllers/StoreBoxController.cs
+++ b/electrostoreAPI/Controllers/StoreBoxController.cs
@@ -73,7 +73,7 @@ namespace ElectrostoreAPI.Controllers
                 id_store = id_store
             }).ToList();
             var boxs = await _boxService.CreateBulkBox(boxsDtoFull);
-            if (boxs.Error.Count == 0)
+            if (boxs.error.Count == 0)
             {
                 return Ok(boxs);
             }
@@ -100,7 +100,7 @@ namespace ElectrostoreAPI.Controllers
         public async Task<ActionResult<ReadBulkBoxDto>> UpdateBulkBox([FromRoute] int id_store, [FromBody] List<UpdateBulkBoxByStoreDto> boxsDto)
         {
             var boxs = await _boxService.UpdateBulkBox(boxsDto, id_store);
-            if (boxs.Error.Count == 0)
+            if (boxs.error.Count == 0)
             {
                 return Ok(boxs);
             }

--- a/electrostoreAPI/Controllers/ZoneController.cs
+++ b/electrostoreAPI/Controllers/ZoneController.cs
@@ -94,11 +94,11 @@ namespace ElectrostoreAPI.Controllers
                 return NotFound("This zone has no picture");
             }
             var result = await _fileService.GetFile(zone.url_picture_zone);
-            if (result.Success && result.FileStream != null)
+            if (result.success && result.file_stream != null)
             {
-                return File(result.FileStream, result.MimeType);
+                return File(result.file_stream, result.mime_type);
             }
-            return NotFound(result.ErrorMessage);
+            return NotFound(result.error_message);
         }
 
         [HttpGet("{id_zone}/thumbnail")]
@@ -111,11 +111,11 @@ namespace ElectrostoreAPI.Controllers
                 return NotFound("This zone has no picture");
             }
             var result = await _fileService.GetFile(zone.url_thumbnail_zone);
-            if (result.Success && result.FileStream != null)
+            if (result.success && result.file_stream != null)
             {
-                return File(result.FileStream, result.MimeType);
+                return File(result.file_stream, result.mime_type);
             }
-            return NotFound(result.ErrorMessage);
+            return NotFound(result.error_message);
         }
     }
 }

--- a/electrostoreAPI/DTO/BoxDto.cs
+++ b/electrostoreAPI/DTO/BoxDto.cs
@@ -23,8 +23,8 @@ public record ReadExtendedBoxDto : ReadBoxDto
 }
 public record ReadBulkBoxDto
 {
-    public required List<ReadBoxDto> Valide { get; init; }
-    public required List<ErrorDetail> Error { get; init; }
+    public required List<ReadBoxDto> valide { get; init; }
+    public required List<ErrorDetail> error { get; init; }
 }
 public record CreateBoxByStoreDto
 {

--- a/electrostoreAPI/DTO/BoxTagDto.cs
+++ b/electrostoreAPI/DTO/BoxTagDto.cs
@@ -16,8 +16,8 @@ public record ReadExtendedBoxTagDto : ReadBoxTagDto
 }
 public record ReadBulkBoxTagDto
 {
-    public required List<ReadBoxTagDto> Valide { get; init; }
-    public required List<ErrorDetail> Error { get; init; }
+    public required List<ReadBoxTagDto> valide { get; init; }
+    public required List<ErrorDetail> error { get; init; }
 }
 public record CreateBoxTagByTagDto
 {

--- a/electrostoreAPI/DTO/CommandItemDto.cs
+++ b/electrostoreAPI/DTO/CommandItemDto.cs
@@ -18,8 +18,8 @@ public record ReadExtendedCommandItemDto : ReadCommandItemDto
 }
 public record ReadBulkCommandItemDto
 {
-    public required List<ReadCommandItemDto> Valide { get; init; }
-    public required List<ErrorDetail> Error { get; init; }
+    public required List<ReadCommandItemDto> valide { get; init; }
+    public required List<ErrorDetail> error { get; init; }
 }
 public record CreateCommandItemByCommandDto
 {

--- a/electrostoreAPI/DTO/EncryptDto.cs
+++ b/electrostoreAPI/DTO/EncryptDto.cs
@@ -2,7 +2,7 @@ namespace ElectrostoreAPI.Dto;
 
 public record EncryptDto
 {
-    public required byte[] EncryptedData { get; init; }
-    public required byte[] IV { get; init; }
-    public required byte[] Tag { get; init; }
+    public required byte[] encrypted_data { get; init; }
+    public required byte[] iv { get; init; }
+    public required byte[] tag { get; init; }
 }

--- a/electrostoreAPI/DTO/FileDto.cs
+++ b/electrostoreAPI/DTO/FileDto.cs
@@ -2,13 +2,13 @@ namespace ElectrostoreAPI.Dto;
 
 public record GetFileResult
 {
-    public Stream? FileStream { get; init; }
-    public required string MimeType { get; init; }
-    public bool Success { get; init; }
-    public string? ErrorMessage { get; init; }
+    public Stream? file_stream { get; init; }
+    public required string mime_type { get; init; }
+    public bool success { get; init; }
+    public string? error_message { get; init; }
 }
 public record SaveFileResult
 {
     public required string path { get; init; }
-    public required string mimeType { get; init; }
+    public required string mime_type { get; init; }
 }

--- a/electrostoreAPI/DTO/ItemTagDto.cs
+++ b/electrostoreAPI/DTO/ItemTagDto.cs
@@ -16,8 +16,8 @@ public record ReadExtendedItemTagDto : ReadItemTagDto
 }
 public record ReadBulkItemTagDto
 {
-    public required List<ReadItemTagDto> Valide { get; init; }
-    public required List<ErrorDetail> Error { get; init; }
+    public required List<ReadItemTagDto> valide { get; init; }
+    public required List<ErrorDetail> error { get; init; }
 }
 public record CreateItemTagByTagDto
 {

--- a/electrostoreAPI/DTO/JWTDto.cs
+++ b/electrostoreAPI/DTO/JWTDto.cs
@@ -30,12 +30,12 @@ public class JwtSettings
 
 public record ErrorDetail
 {
-    public required string Reason { get; init; }
-    public required object Data { get; init; }
+    public required string reason { get; init; }
+    public required object data { get; init; }
 }
 
 public record SsoUrlResponse
 {
-    public required string AuthUrl { get; init; }
-    public required string State { get; init; }
+    public required string auth_url { get; init; }
+    public required string state { get; init; }
 }

--- a/electrostoreAPI/DTO/LedDto.cs
+++ b/electrostoreAPI/DTO/LedDto.cs
@@ -14,8 +14,8 @@ public record ReadLedDto
 }
 public record ReadBulkLedDto
 {
-    public required List<ReadLedDto> Valide { get; init; }
-    public required List<ErrorDetail> Error { get; init; }
+    public required List<ReadLedDto> valide { get; init; }
+    public required List<ErrorDetail> error { get; init; }
 }
 public record CreateLedByStoreDto
 {

--- a/electrostoreAPI/DTO/LoginRequest.cs
+++ b/electrostoreAPI/DTO/LoginRequest.cs
@@ -7,44 +7,44 @@ public record LoginRequest
 {
     [Required(ErrorMessage = "{0} is required.")]
     [OptionalNotEmpty(ErrorMessage = "{0} cannot be empty or whitespace.")]
-    public required string Email { get; set; }
+    public required string email { get; set; }
 
     [Required(ErrorMessage = "{0} is required.")]
     [OptionalNotEmpty(ErrorMessage = "{0} cannot be empty or whitespace.")]
-    public required string Password { get; set; }
+    public required string password { get; set; }
 }
 
 public record ForgotPasswordRequest
 {
     [Required(ErrorMessage = "{0} is required.")]
     [OptionalNotEmpty(ErrorMessage = "{0} cannot be empty or whitespace.")]
-    public required string Email { get; set; }
+    public required string email { get; set; }
 }
 
 public record ResetPasswordRequest
 {
     [Required(ErrorMessage = "{0} is required.")]
     [OptionalNotEmpty(ErrorMessage = "{0} cannot be empty or whitespace.")]
-    public required string Email { get; set; }
+    public required string email { get; set; }
 
     [Required(ErrorMessage = "{0} is required.")]
     [OptionalNotEmpty(ErrorMessage = "{0} cannot be empty or whitespace.")]
-    public required string Token { get; set; }
+    public required string token { get; set; }
 
     [Required(ErrorMessage = "{0} is required.")]
     [OptionalNotEmpty(ErrorMessage = "{0} cannot be empty or whitespace.")]
     [RegularExpression(@"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^a-zA-Z0-9]).{8,}$",
         ErrorMessage = "{0} must contain a number and a special character and a uppercase letter and a lowercase letter and if it's at least 8 characters long")]
-    public required string Password { get; set; }
+    public required string password { get; set; }
 }
 
 public record SsoLoginRequest
 {
     [Required(ErrorMessage = "{0} is required.")]
     [OptionalNotEmpty(ErrorMessage = "{0} cannot be empty or whitespace.")]
-    public required string Code { get; set; }
+    public required string code { get; set; }
 
     [Required(ErrorMessage = "{0} is required.")]
     [OptionalNotEmpty(ErrorMessage = "{0} cannot be empty or whitespace.")]
-    public required string State { get; set; }
+    public required string state { get; set; }
 }

--- a/electrostoreAPI/DTO/ProjectItemDto.cs
+++ b/electrostoreAPI/DTO/ProjectItemDto.cs
@@ -17,8 +17,8 @@ public record ReadExtendedProjectItemDto : ReadProjectItemDto
 }
 public record ReadBulkProjectItemDto
 {
-    public required List<ReadProjectItemDto> Valide { get; init; }
-    public required List<ErrorDetail> Error { get; init; }
+    public required List<ReadProjectItemDto> valide { get; init; }
+    public required List<ErrorDetail> error { get; init; }
 }
 public record CreateProjectItemByProjectDto
 {

--- a/electrostoreAPI/DTO/ProjectProjectTagDto.cs
+++ b/electrostoreAPI/DTO/ProjectProjectTagDto.cs
@@ -16,8 +16,8 @@ public record ReadExtendedProjectProjectTagDto : ReadProjectProjectTagDto
 }
 public record ReadBulkProjectProjectTagDto
 {
-    public required List<ReadProjectProjectTagDto> Valide { get; init; }
-    public required List<ErrorDetail> Error { get; init; }
+    public required List<ReadProjectProjectTagDto> valide { get; init; }
+    public required List<ErrorDetail> error { get; init; }
 }
 public record CreateProjectProjectTagByProjectTagDto
 {

--- a/electrostoreAPI/DTO/ProjectTagDto.cs
+++ b/electrostoreAPI/DTO/ProjectTagDto.cs
@@ -19,8 +19,8 @@ public record ReadExtendedProjectTagDto : ReadProjectTagDto
 
 public record ReadBulkProjectTagDto
 {
-    public required List<ReadProjectTagDto> Valide { get; init; }
-    public required List<ErrorDetail> Error { get; init; }
+    public required List<ReadProjectTagDto> valide { get; init; }
+    public required List<ErrorDetail> error { get; init; }
 }
 
 public record CreateProjectTagDto

--- a/electrostoreAPI/DTO/StatusDto.cs
+++ b/electrostoreAPI/DTO/StatusDto.cs
@@ -10,7 +10,7 @@ public record ReadStatusDto
     public int ai_training_in_progress { get; init; }
     public required string notif_status { get; init; }
     public bool? notif_smtp { get; init; }
-    public bool? notif_webPush { get; init; }
+    public bool? notif_web_push { get; init; }
     public required string cron_status { get; init; }
     public required string worker_status { get; init; }
     public Dictionary<string, string> external_services { get; init; } = new();

--- a/electrostoreAPI/DTO/StoreTagDto.cs
+++ b/electrostoreAPI/DTO/StoreTagDto.cs
@@ -16,8 +16,8 @@ public record ReadExtendedStoreTagDto : ReadStoreTagDto
 }
 public record ReadBulkStoreTagDto
 {
-    public required List<ReadStoreTagDto> Valide { get; init; }
-    public required List<ErrorDetail> Error { get; init; }
+    public required List<ReadStoreTagDto> valide { get; init; }
+    public required List<ErrorDetail> error { get; init; }
 }
 public record CreateStoreTagByTagDto
 {

--- a/electrostoreAPI/DTO/TagDto.cs
+++ b/electrostoreAPI/DTO/TagDto.cs
@@ -23,8 +23,8 @@ public record ReadExtendedTagDto : ReadTagDto
 
 public record ReadBulkTagDto
 {
-    public required List<ReadTagDto> Valide { get; init; }
-    public required List<ErrorDetail> Error { get; init; }
+    public required List<ReadTagDto> valide { get; init; }
+    public required List<ErrorDetail> error { get; init; }
 }
 
 public record CreateTagDto

--- a/electrostoreAPI/DTO/filterDto.cs
+++ b/electrostoreAPI/DTO/filterDto.cs
@@ -2,13 +2,13 @@ namespace ElectrostoreAPI.Dto;
 
 public record SorterDto
 {
-    public required string Field { get; set; }
-    public required string Order { get; set; }
+    public required string field { get; set; }
+    public required string order { get; set; }
 }
 
 public record FilterDto
 {
-    public required string Field { get; set; }
-    public required string SearchType { get; set; }
-    public required string Value { get; set; }
+    public required string field { get; set; }
+    public required string search_type { get; set; }
+    public required string value { get; set; }
 }

--- a/electrostoreAPI/DTO/paginatedReponseDto.cs
+++ b/electrostoreAPI/DTO/paginatedReponseDto.cs
@@ -5,8 +5,8 @@ public record PaginationDto
     public int limit { get; set; }
     public int offset { get; set; }
     public int total { get; set; }
-    public int nextOffset { get; set; }
-    public bool hasMore { get; set; }
+    public int next_offset { get; set; }
+    public bool has_more { get; set; }
 }
 
 public record PaginatedResponseDto<T>

--- a/electrostoreAPI/Extensions/ParserExtensions.cs
+++ b/electrostoreAPI/Extensions/ParserExtensions.cs
@@ -30,7 +30,7 @@ public static class ParserExtensions
 
             if (searchType != null)
             {
-                filters.Add(new FilterDto { Field = field, Value = value, SearchType = searchType });
+                filters.Add(new FilterDto { field = field, value = value, search_type = searchType });
             }
         }
         return filters;
@@ -40,17 +40,17 @@ public static class ParserExtensions
     {
         if (string.IsNullOrEmpty(sort))
         {
-            return new SorterDto { Field = "", Order = "asc" };
+            return new SorterDto { field = "", order = "asc" };
         }
         var parts = sort.Split(',', StringSplitOptions.RemoveEmptyEntries);
         if (parts.Length != 2)
         {
-            return new SorterDto { Field = "", Order = "asc" };
+            return new SorterDto { field = "", order = "asc" };
         }
 
         var field = parts[0].Trim();
         var order = parts[1].Trim().ToLower() == "desc" ? "desc" : "asc";
 
-        return new SorterDto { Field = field, Order = order };
+        return new SorterDto { field = field, order = order };
     }
 }

--- a/electrostoreAPI/Extensions/RsqlParserExtensions.cs
+++ b/electrostoreAPI/Extensions/RsqlParserExtensions.cs
@@ -176,9 +176,9 @@ public static class RsqlParserExtensions
         Expression? combined = null;
         foreach (var condition in rsql)
         {
-            var field = condition.Field;
-            var searchType = condition.SearchType;
-            var value = condition.Value;
+            var field = condition.field;
+            var searchType = condition.search_type;
+            var value = condition.value;
 
             Expression? binaryExpression = null;
 
@@ -333,12 +333,12 @@ public static class RsqlParserExtensions
 
     public static (Expression<Func<T, object>>?, string) ToSortExpression<T>(SorterDto sort)
     {
-        if (string.IsNullOrEmpty(sort.Field))
+        if (string.IsNullOrEmpty(sort.field))
         {
             return (null, "asc");
         }
-        var field = sort.Field;
-        var direction = sort.Order?.ToLower() == "desc" ? "desc" : "asc";
+        var field = sort.field;
+        var direction = sort.order?.ToLower() == "desc" ? "desc" : "asc";
 
         ParameterExpression param = Expression.Parameter(typeof(T), "x");
 

--- a/electrostoreAPI/Services/AiToolExecutorService/AiToolExecutorService.cs
+++ b/electrostoreAPI/Services/AiToolExecutorService/AiToolExecutorService.cs
@@ -154,7 +154,7 @@ public class AiToolExecutorService : IAiToolExecutorService
         var rsql = new List<FilterDto>();
         if (!string.IsNullOrWhiteSpace(args.query))
         {
-            rsql.Add(new FilterDto { Field = "friendly_name_item", SearchType = "like", Value = args.query });
+            rsql.Add(new FilterDto { field = "friendly_name_item", search_type = "like", value = args.query });
         }
         var items = await _itemService.GetItems(limit: args.limit ?? 20, rsql: rsql.Count > 0 ? rsql : null);
         return Result(items.data);
@@ -198,7 +198,7 @@ public class AiToolExecutorService : IAiToolExecutorService
         var rsql = new List<FilterDto>();
         if (!string.IsNullOrWhiteSpace(args.query))
         {
-            rsql.Add(new FilterDto { Field = "name_tag", SearchType = "like", Value = args.query });
+            rsql.Add(new FilterDto { field = "name_tag", search_type = "like", value = args.query });
         }
         var tags = await _tagService.GetTags(limit: 50, rsql: rsql.Count > 0 ? rsql : null);
         return Result(tags.data);

--- a/electrostoreAPI/Services/AuthService/AuthService.cs
+++ b/electrostoreAPI/Services/AuthService/AuthService.cs
@@ -70,18 +70,18 @@ public class AuthService : IAuthService
         var authUrl = $"{authority}?{queryParams}";
         return new SsoUrlResponse
         {
-            AuthUrl = authUrl,
-            State = state
+            auth_url = authUrl,
+            state = state
         };
     }
 
     public async Task<LoginResponse> LoginWithSSO(string sso_method, SsoLoginRequest request)
     {
-        if (!_stateStore.TryGetValue(request.State, out DateTime value) || value < DateTime.UtcNow)
+        if (!_stateStore.TryGetValue(request.state, out DateTime value) || value < DateTime.UtcNow)
         {
             throw new UnauthorizedAccessException("Invalid or expired state parameter");
         }
-        _stateStore.Remove(request.State);
+        _stateStore.Remove(request.state);
         var ssoModuleConfig = _configuration.GetSection("OAuth:" + ToPascalCase(sso_method));
         var clientId = ssoModuleConfig["ClientId"];
         var clientSecret = ssoModuleConfig["ClientSecret"];
@@ -93,7 +93,7 @@ public class AuthService : IAuthService
         {
             throw new ArgumentException("SSO method configuration is invalid");
         }
-        var tokenResponse = await ExchangeCodeForToken(request.Code, clientId!, clientSecret!, authority!, redirectUri!);
+        var tokenResponse = await ExchangeCodeForToken(request.code, clientId!, clientSecret!, authority!, redirectUri!);
         var userInfo = await GetUserInfo(tokenResponse.access_token, authority!);
         _logger.LogDebug("SSO user info received: {UserInfo}", JsonSerializer.Serialize(userInfo));
         var user = await GetOrCreateUser(userInfo, groupMappingSection);
@@ -230,7 +230,7 @@ public class AuthService : IAuthService
             throw new InvalidOperationException("SMTP is not enabled");
         }
         // check if user exists
-        var user = await _context.Users.FirstOrDefaultAsync(u => u.email_user == request.Email);
+        var user = await _context.Users.FirstOrDefaultAsync(u => u.email_user == request.email);
         if (user is not null)
         {
             // add reset_token
@@ -273,10 +273,10 @@ public class AuthService : IAuthService
         }
         // check if token is valid
         var user = await _context.Users.FirstOrDefaultAsync(
-            u => u.email_user == request.Email && u.reset_token.ToString() == request.Token && u.reset_token_expiration > DateTime.Now
+            u => u.email_user == request.email && u.reset_token.ToString() == request.token && u.reset_token_expiration > DateTime.Now
         ) ?? throw new InvalidOperationException("Invalid token");
         // update password
-        user.password_user = BCrypt.Net.BCrypt.HashPassword(request.Password);
+        user.password_user = BCrypt.Net.BCrypt.HashPassword(request.password);
         user.reset_token = null;
         user.reset_token_expiration = null;
         await _context.SaveChangesAsync();
@@ -307,9 +307,9 @@ public class AuthService : IAuthService
     public async Task<LoginResponse> LoginWithPassword(LoginRequest request)
     {
         // check if user exists
-        var user = await _context.Users.FirstOrDefaultAsync(u => u.email_user == request.Email) ?? throw new UnauthorizedAccessException("Invalid password"); // do not reveal if email exists
+        var user = await _context.Users.FirstOrDefaultAsync(u => u.email_user == request.email) ?? throw new UnauthorizedAccessException("Invalid password"); // do not reveal if email exists
         // check if password is correct
-        if (!BCrypt.Net.BCrypt.Verify(request.Password, user.password_user))
+        if (!BCrypt.Net.BCrypt.Verify(request.password, user.password_user))
         {
             throw new UnauthorizedAccessException("Invalid password");
         }

--- a/electrostoreAPI/Services/BoxService/BoxService.cs
+++ b/electrostoreAPI/Services/BoxService/BoxService.cs
@@ -36,13 +36,13 @@ public class BoxService : IBoxService
         var query = _context.Boxs.AsQueryable();
         var filterResult = default(Expression<Func<Boxs, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_store", SearchType = "eq", Value = storeId.ToString() });
+        rsql.Add(new FilterDto { field = "id_store", search_type = "eq", value = storeId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<Boxs>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<Boxs>(sort);
             if (sortResult.Item1 != null)
@@ -51,7 +51,7 @@ public class BoxService : IBoxService
             }
             else
             {
-                sort = new SorterDto { Field = "id_box", Order = "asc" };
+                sort = new SorterDto { field = "id_box", order = "asc" };
                 query = query.OrderBy(b => b.id_box);
             }
         }
@@ -84,8 +84,8 @@ public class BoxService : IBoxService
             pagination = new PaginationDto
             {
                 total = await _context.Boxs.CountAsync(filterResult ?? (b => b.id_store == storeId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.Boxs.Skip(offset + limit).AnyAsync(filterResult ?? (b => b.id_store == storeId))
+                next_offset = offset + limit,
+                has_more = await _context.Boxs.Skip(offset + limit).AnyAsync(filterResult ?? (b => b.id_store == storeId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -159,8 +159,8 @@ public class BoxService : IBoxService
             {
                 errorQuery.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = boxDto
+                    reason = e.Message,
+                    data = boxDto
                 });
             }
         }
@@ -170,8 +170,8 @@ public class BoxService : IBoxService
         }
         return new ReadBulkBoxDto
         {
-            Valide = validQuery,
-            Error = errorQuery
+            valide = validQuery,
+            error = errorQuery
         };
     }
 
@@ -223,8 +223,8 @@ public class BoxService : IBoxService
             {
                 errorQuery.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = boxDto
+                    reason = e.Message,
+                    data = boxDto
                 });
             }
         }
@@ -242,8 +242,8 @@ public class BoxService : IBoxService
                 {
                     errorQuery.Add(new ErrorDetail
                     {
-                        Reason = e.Message,
-                        Data = boxDto
+                        reason = e.Message,
+                        data = boxDto
                     });
                 }
             }
@@ -254,8 +254,8 @@ public class BoxService : IBoxService
         }
         return new ReadBulkBoxDto
         {
-            Valide = validQuery,
-            Error = errorQuery
+            valide = validQuery,
+            error = errorQuery
         };
     }
 
@@ -303,15 +303,15 @@ public class BoxService : IBoxService
             {
                 errorQuery.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = id
+                    reason = e.Message,
+                    data = id
                 });
             }
         }
         return new ReadBulkBoxDto
         {
-            Valide = validQuery,
-            Error = errorQuery
+            valide = validQuery,
+            error = errorQuery
         };
     }
 }

--- a/electrostoreAPI/Services/BoxTagService/BoxTagService.cs
+++ b/electrostoreAPI/Services/BoxTagService/BoxTagService.cs
@@ -32,14 +32,14 @@ public class BoxTagService : IBoxTagService
         }
         var query = _context.BoxsTags.AsQueryable();
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_box", SearchType = "eq", Value = boxId.ToString() });
+        rsql.Add(new FilterDto { field = "id_box", search_type = "eq", value = boxId.ToString() });
         var filterResult = default(Expression<Func<BoxsTags, bool>>);
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<BoxsTags>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<BoxsTags>(sort);
             if (sortResult.Item1 != null)
@@ -48,7 +48,7 @@ public class BoxTagService : IBoxTagService
             }
             else
             {
-                sort = new SorterDto { Field = "id_tag", Order = "asc" };
+                sort = new SorterDto { field = "id_tag", order = "asc" };
                 query = query.OrderBy(bt => bt.id_tag);
             }
         }
@@ -74,8 +74,8 @@ public class BoxTagService : IBoxTagService
                 offset = offset,
                 limit = limit,
                 total = await _context.BoxsTags.CountAsync(filterResult ?? (bt => true)),
-                nextOffset = offset + limit,
-                hasMore = await _context.BoxsTags.Skip(offset + limit).AnyAsync(filterResult ?? (bt => true))
+                next_offset = offset + limit,
+                has_more = await _context.BoxsTags.Skip(offset + limit).AnyAsync(filterResult ?? (bt => true))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -92,14 +92,14 @@ public class BoxTagService : IBoxTagService
         }
         var query = _context.BoxsTags.AsQueryable();
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_tag", SearchType = "eq", Value = tagId.ToString() });
+        rsql.Add(new FilterDto { field = "id_tag", search_type = "eq", value = tagId.ToString() });
         var filterResult = default(Expression<Func<BoxsTags, bool>>);
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<BoxsTags>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<BoxsTags>(sort);
             if (sortResult.Item1 != null)
@@ -108,7 +108,7 @@ public class BoxTagService : IBoxTagService
             }
             else
             {
-                sort = new SorterDto { Field = "id_box", Order = "asc" };
+                sort = new SorterDto { field = "id_box", order = "asc" };
                 query = query.OrderBy(bt => bt.id_box);
             }
         }
@@ -134,8 +134,8 @@ public class BoxTagService : IBoxTagService
                 offset = offset,
                 limit = limit,
                 total = await _context.BoxsTags.CountAsync(filterResult ?? (bt => true)),
-                nextOffset = offset + limit,
-                hasMore = await _context.BoxsTags.Skip(offset + limit).AnyAsync(filterResult ?? (bt => true))
+                next_offset = offset + limit,
+                has_more = await _context.BoxsTags.Skip(offset + limit).AnyAsync(filterResult ?? (bt => true))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -205,15 +205,15 @@ public class BoxTagService : IBoxTagService
             {
                 errorQuery.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = boxTagDto
+                    reason = e.Message,
+                    data = boxTagDto
                 });
             }
         }
         return new ReadBulkBoxTagDto
         {
-            Valide = validQuery,
-            Error = errorQuery
+            valide = validQuery,
+            error = errorQuery
         };
     }
 
@@ -261,15 +261,15 @@ public class BoxTagService : IBoxTagService
             {
                 errorQuery.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = boxTagDto
+                    reason = e.Message,
+                    data = boxTagDto
                 });
             }
         }
         return new ReadBulkBoxTagDto
         {
-            Valide = validQuery,
-            Error = errorQuery
+            valide = validQuery,
+            error = errorQuery
         };
     }
 }

--- a/electrostoreAPI/Services/CarrierService/CarrierService.cs
+++ b/electrostoreAPI/Services/CarrierService/CarrierService.cs
@@ -40,7 +40,7 @@ public class CarrierService : ICarrierService
                 (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<Carriers>(rsql);
                 query = query.Where(filterResult);
             }
-            if (!string.IsNullOrEmpty(sort?.Field))
+            if (!string.IsNullOrEmpty(sort?.field))
             {
                 var sortResult = RsqlParserExtensions.ToSortExpression<Carriers>(sort);
                 if (sortResult.Item1 != null)
@@ -49,7 +49,7 @@ public class CarrierService : ICarrierService
                 }
                 else
                 {
-                    sort = new SorterDto { Field = "id_carrier", Order = "asc" };
+                    sort = new SorterDto { field = "id_carrier", order = "asc" };
                     query = query.OrderBy(c => c.id_carrier);
                 }
             }
@@ -68,8 +68,8 @@ public class CarrierService : ICarrierService
                 offset = offset,
                 limit = limit,
                 total = await _context.Carriers.CountAsync(filterResult ?? (c => true)),
-                nextOffset = offset + limit,
-                hasMore = await _context.Carriers.Skip(offset + limit).AnyAsync(filterResult ?? (c => true))
+                next_offset = offset + limit,
+                has_more = await _context.Carriers.Skip(offset + limit).AnyAsync(filterResult ?? (c => true))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null

--- a/electrostoreAPI/Services/CommandCommentService/CommandCommentService.cs
+++ b/electrostoreAPI/Services/CommandCommentService/CommandCommentService.cs
@@ -33,13 +33,13 @@ public class CommandCommentService : ICommandCommentService
         var query = _context.CommandsComments.AsQueryable();
         var filterResult = default(Expression<Func<CommandsComments, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_command", SearchType = "eq", Value = CommandId.ToString() });
+        rsql.Add(new FilterDto { field = "id_command", search_type = "eq", value = CommandId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<CommandsComments>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<CommandsComments>(sort);
             if (sortResult.Item1 != null)
@@ -48,7 +48,7 @@ public class CommandCommentService : ICommandCommentService
             }
             else
             {
-                sort = new SorterDto { Field = "created_at", Order = "desc" };
+                sort = new SorterDto { field = "created_at", order = "desc" };
                 query = query.OrderByDescending(cc => cc.created_at);
             }
         }
@@ -74,8 +74,8 @@ public class CommandCommentService : ICommandCommentService
                 offset = offset,
                 limit = limit,
                 total = await _context.CommandsComments.CountAsync(filterResult ?? (cc => cc.id_command == CommandId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.CommandsComments.Skip(offset + limit).AnyAsync(filterResult ?? (cc => cc.id_command == CommandId))
+                next_offset = offset + limit,
+                has_more = await _context.CommandsComments.Skip(offset + limit).AnyAsync(filterResult ?? (cc => cc.id_command == CommandId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -93,13 +93,13 @@ public class CommandCommentService : ICommandCommentService
         var query = _context.CommandsComments.AsQueryable();
         var filterResult = default(Expression<Func<CommandsComments, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_user", SearchType = "eq", Value = userId.ToString() });
+        rsql.Add(new FilterDto { field = "id_user", search_type = "eq", value = userId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<CommandsComments>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<CommandsComments>(sort);
             if (sortResult.Item1 != null)
@@ -108,7 +108,7 @@ public class CommandCommentService : ICommandCommentService
             }
             else
             {
-                sort = new SorterDto { Field = "created_at", Order = "desc" };
+                sort = new SorterDto { field = "created_at", order = "desc" };
                 query = query.OrderByDescending(cc => cc.created_at);
             }
         }
@@ -134,8 +134,8 @@ public class CommandCommentService : ICommandCommentService
                 offset = offset,
                 limit = limit,
                 total = await _context.CommandsComments.CountAsync(filterResult ?? (cc => cc.id_user == userId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.CommandsComments.Skip(offset + limit).AnyAsync(filterResult ?? (cc => cc.id_user == userId))
+                next_offset = offset + limit,
+                has_more = await _context.CommandsComments.Skip(offset + limit).AnyAsync(filterResult ?? (cc => cc.id_user == userId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null

--- a/electrostoreAPI/Services/CommandDocumentService/CommandDocumentService.cs
+++ b/electrostoreAPI/Services/CommandDocumentService/CommandDocumentService.cs
@@ -33,13 +33,13 @@ public class CommandDocumentService : ICommandDocumentService
         var query = _context.CommandsDocuments.AsQueryable();
         var filterResult = default(Expression<Func<CommandsDocuments, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_command", SearchType = "eq", Value = commandId.ToString() });
+        rsql.Add(new FilterDto { field = "id_command", search_type = "eq", value = commandId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<CommandsDocuments>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<CommandsDocuments>(sort);
             if (sortResult.Item1 != null)
@@ -48,7 +48,7 @@ public class CommandDocumentService : ICommandDocumentService
             }
             else
             {
-                sort = new SorterDto { Field = "id_command_document", Order = "asc" };
+                sort = new SorterDto { field = "id_command_document", order = "asc" };
                 query = query.OrderBy(cd => cd.id_command_document);
             }
         }
@@ -66,8 +66,8 @@ public class CommandDocumentService : ICommandDocumentService
                 offset = offset,
                 limit = limit,
                 total = await _context.CommandsDocuments.CountAsync(filterResult ?? (cd => cd.id_command == commandId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.CommandsDocuments.Skip(offset + limit).AnyAsync(filterResult ?? (cd => cd.id_command == commandId))
+                next_offset = offset + limit,
+                has_more = await _context.CommandsDocuments.Skip(offset + limit).AnyAsync(filterResult ?? (cd => cd.id_command == commandId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -97,7 +97,7 @@ public class CommandDocumentService : ICommandDocumentService
             id_command = commandDocumentDto.id_command,
             url_command_document = savedFile.path,
             name_command_document = commandDocumentDto.name_command_document,
-            type_command_document = savedFile.mimeType,
+            type_command_document = savedFile.mime_type,
             size_command_document = commandDocumentDto.document.Length
         };
         await _context.CommandsDocuments.AddAsync(commandDocument);

--- a/electrostoreAPI/Services/CommandHistoryService/CommandHistoryService.cs
+++ b/electrostoreAPI/Services/CommandHistoryService/CommandHistoryService.cs
@@ -29,13 +29,13 @@ public class CommandHistoryService : ICommandHistoryService
         var query = _context.CommandsHistory.AsQueryable();
         var filterResult = default(Expression<Func<CommandsHistory, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_command", SearchType = "eq", Value = idCommand.ToString() });
+        rsql.Add(new FilterDto { field = "id_command", search_type = "eq", value = idCommand.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<CommandsHistory>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<CommandsHistory>(sort);
             if (sortResult.Item1 != null)
@@ -44,13 +44,13 @@ public class CommandHistoryService : ICommandHistoryService
             }
             else
             {
-                sort = new SorterDto { Field = "created_at", Order = "desc" };
+                sort = new SorterDto { field = "created_at", order = "desc" };
                 query = query.OrderByDescending(ch => ch.created_at);
             }
         }
         else
         {
-            sort = new SorterDto { Field = "created_at", Order = "desc" };
+            sort = new SorterDto { field = "created_at", order = "desc" };
             query = query.OrderByDescending(ch => ch.created_at);
         }
         query = query.Skip(offset).Take(limit);
@@ -63,8 +63,8 @@ public class CommandHistoryService : ICommandHistoryService
                 offset = offset,
                 limit = limit,
                 total = await _context.CommandsHistory.CountAsync(filterResult ?? (ci => ci.id_command == idCommand)),
-                nextOffset = offset + limit,
-                hasMore = await _context.CommandsHistory.Skip(offset + limit).AnyAsync(filterResult ?? (ci => ci.id_command == idCommand))
+                next_offset = offset + limit,
+                has_more = await _context.CommandsHistory.Skip(offset + limit).AnyAsync(filterResult ?? (ci => ci.id_command == idCommand))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null

--- a/electrostoreAPI/Services/CommandItemService/CommandItemService.cs
+++ b/electrostoreAPI/Services/CommandItemService/CommandItemService.cs
@@ -29,13 +29,13 @@ public class CommandItemService : ICommandItemService
         var query = _context.CommandsItems.AsQueryable();
         var filterResult = default(Expression<Func<CommandsItems, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_command", SearchType = "eq", Value = commandId.ToString() });
+        rsql.Add(new FilterDto { field = "id_command", search_type = "eq", value = commandId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<CommandsItems>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<CommandsItems>(sort);
             if (sortResult.Item1 != null)
@@ -44,7 +44,7 @@ public class CommandItemService : ICommandItemService
             }
             else
             {
-                sort = new SorterDto { Field = "id_item", Order = "asc" };
+                sort = new SorterDto { field = "id_item", order = "asc" };
                 query = query.OrderBy(ci => ci.id_item);
             }
         }
@@ -70,8 +70,8 @@ public class CommandItemService : ICommandItemService
                 offset = offset,
                 limit = limit,
                 total = await _context.CommandsItems.CountAsync(filterResult ?? (ci => ci.id_command == commandId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.CommandsItems.Skip(offset + limit).AnyAsync(filterResult ?? (ci => ci.id_command == commandId))
+                next_offset = offset + limit,
+                has_more = await _context.CommandsItems.Skip(offset + limit).AnyAsync(filterResult ?? (ci => ci.id_command == commandId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -89,13 +89,13 @@ public class CommandItemService : ICommandItemService
         var query = _context.CommandsItems.AsQueryable();
         var filterResult = default(Expression<Func<CommandsItems, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_item", SearchType = "eq", Value = itemId.ToString() });
+        rsql.Add(new FilterDto { field = "id_item", search_type = "eq", value = itemId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<CommandsItems>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<CommandsItems>(sort);
             if (sortResult.Item1 != null)
@@ -104,7 +104,7 @@ public class CommandItemService : ICommandItemService
             }
             else
             {
-                sort = new SorterDto { Field = "id_command", Order = "asc" };
+                sort = new SorterDto { field = "id_command", order = "asc" };
                 query = query.OrderBy(ci => ci.id_command);
             }
         }
@@ -130,8 +130,8 @@ public class CommandItemService : ICommandItemService
                 offset = offset,
                 limit = limit,
                 total = await _context.CommandsItems.CountAsync(filterResult ?? (ci => ci.id_item == itemId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.CommandsItems.Skip(offset + limit).AnyAsync(filterResult ?? (ci => ci.id_item == itemId))
+                next_offset = offset + limit,
+                has_more = await _context.CommandsItems.Skip(offset + limit).AnyAsync(filterResult ?? (ci => ci.id_item == itemId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -191,15 +191,15 @@ public class CommandItemService : ICommandItemService
             {
                 errorQuery.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = commandItemDto
+                    reason = e.Message,
+                    data = commandItemDto
                 });
             }
         }
         return new ReadBulkCommandItemDto
         {
-            Valide = validQuery,
-            Error = errorQuery
+            valide = validQuery,
+            error = errorQuery
         };
     }
 

--- a/electrostoreAPI/Services/CommandService/CommandService.cs
+++ b/electrostoreAPI/Services/CommandService/CommandService.cs
@@ -43,7 +43,7 @@ public class CommandService : ICommandService
                 (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<Commands>(rsql);
                 query = query.Where(filterResult);
             }
-            if (!string.IsNullOrEmpty(sort?.Field))
+            if (!string.IsNullOrEmpty(sort?.field))
             {
                 var sortResult = RsqlParserExtensions.ToSortExpression<Commands>(sort);
                 if (sortResult.Item1 != null)
@@ -52,7 +52,7 @@ public class CommandService : ICommandService
                 }
                 else
                 {
-                    sort = new SorterDto { Field = "id_command", Order = "asc" };
+                    sort = new SorterDto { field = "id_command", order = "asc" };
                     query = query.OrderBy(c => c.id_command);
                 }
             }
@@ -96,8 +96,8 @@ public class CommandService : ICommandService
                 offset = offset,
                 limit = limit,
                 total = await _context.Commands.CountAsync(filterResult ?? (c => true)),
-                nextOffset = offset + limit,
-                hasMore = await _context.Commands.Skip(offset + limit).AnyAsync(filterResult ?? (c => true))
+                next_offset = offset + limit,
+                has_more = await _context.Commands.Skip(offset + limit).AnyAsync(filterResult ?? (c => true))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null

--- a/electrostoreAPI/Services/CronJobService/CronJobService.cs
+++ b/electrostoreAPI/Services/CronJobService/CronJobService.cs
@@ -39,7 +39,7 @@ public class CronJobService : ICronJobService
                 (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<CronJobs>(rsql);
                 query = query.Where(filterResult);
             }
-            if (!string.IsNullOrEmpty(sort?.Field))
+            if (!string.IsNullOrEmpty(sort?.field))
             {
                 var sortResult = RsqlParserExtensions.ToSortExpression<CronJobs>(sort);
                 if (sortResult.Item1 != null)
@@ -67,8 +67,8 @@ public class CronJobService : ICronJobService
                 offset = offset,
                 limit = limit,
                 total = total,
-                nextOffset = offset + limit,
-                hasMore = await _context.CronJobs.Skip(offset + limit).AnyAsync(filterResult ?? (c => true))
+                next_offset = offset + limit,
+                has_more = await _context.CronJobs.Skip(offset + limit).AnyAsync(filterResult ?? (c => true))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null

--- a/electrostoreAPI/Services/EncryptionService/EncryptionService.cs
+++ b/electrostoreAPI/Services/EncryptionService/EncryptionService.cs
@@ -26,9 +26,9 @@ public class EncryptionService : IEncryptionService
 
         return new EncryptDto
         {
-            EncryptedData = ciphertextBytes,
-            IV = iv,
-            Tag = tag
+            encrypted_data = ciphertextBytes,
+            iv = iv,
+            tag = tag
         };
     }
 
@@ -40,11 +40,11 @@ public class EncryptionService : IEncryptionService
             throw new ArgumentException("Key must be 32 bytes (256 bits) long.");
         }
         using AesGcm aesGcm = new AesGcm(key, AesGcm.TagByteSizes.MaxSize);
-        byte[] decryptedBytes = new byte[encryptDto.EncryptedData.Length];
+        byte[] decryptedBytes = new byte[encryptDto.encrypted_data.Length];
 
         try
         {
-            aesGcm.Decrypt(encryptDto.IV, encryptDto.EncryptedData, encryptDto.Tag, decryptedBytes);
+            aesGcm.Decrypt(encryptDto.iv, encryptDto.encrypted_data, encryptDto.tag, decryptedBytes);
             return Encoding.UTF8.GetString(decryptedBytes);
         }
         catch (CryptographicException)

--- a/electrostoreAPI/Services/FileService/FileService.cs
+++ b/electrostoreAPI/Services/FileService/FileService.cs
@@ -28,9 +28,9 @@ public class FileService : IFileService
             {
                 return new GetFileResult
                 {
-                    Success = false,
-                    ErrorMessage = "S3 is enabled but MinIO client is not configured",
-                    MimeType = ""
+                    success = false,
+                    error_message = "S3 is enabled but MinIO client is not configured",
+                    mime_type = ""
                 };
             }
             var objectContent = new MemoryStream();
@@ -63,18 +63,18 @@ public class FileService : IFileService
                 };
                 return new GetFileResult
                 {
-                    Success = true,
-                    FileStream = objectContent,
-                    MimeType = mimeType
+                    success = true,
+                    file_stream = objectContent,
+                    mime_type = mimeType
                 };
             }
             catch (Minio.Exceptions.ObjectNotFoundException)
             {
                 return new GetFileResult
                 {
-                    Success = false,
-                    ErrorMessage = "File not found",
-                    MimeType = ""
+                    success = false,
+                    error_message = "File not found",
+                    mime_type = ""
                 };
             }
         }
@@ -110,18 +110,18 @@ public class FileService : IFileService
                 FileStream.Position = 0;
                 return new GetFileResult
                 {
-                    Success = true,
-                    FileStream = FileStream,
-                    MimeType = mimeType
+                    success = true,
+                    file_stream = FileStream,
+                    mime_type = mimeType
                 };
             }
             else
             {
                 return new GetFileResult
                 {
-                    Success = false,
-                    ErrorMessage = "File not found",
-                    MimeType = ""
+                    success = false,
+                    error_message = "File not found",
+                    mime_type = ""
                 };
             }
         }
@@ -234,7 +234,7 @@ public class FileService : IFileService
         return new SaveFileResult
         {
             path = filePath,
-            mimeType = contentType
+            mime_type = contentType
         };
     }
 
@@ -242,15 +242,15 @@ public class FileService : IFileService
     {
         // if S3 is used, get the file from S3, generate the thumbnail and upload it back to S3
         var file = await GetFile(sourceFilePath);
-        if (!file.Success || file.FileStream == null)
+        if (!file.success || file.file_stream == null)
         {
             return new SaveFileResult
             {
                 path = "",
-                mimeType = ""
+                mime_type = ""
             };
         }
-        var image = await Image.LoadAsync(file.FileStream);
+        var image = await Image.LoadAsync(file.file_stream);
         image.Mutate(x => x.Resize(new ResizeOptions
         {
             Size = new Size(width, height),

--- a/electrostoreAPI/Services/ItemBoxService/ItemBoxService.cs
+++ b/electrostoreAPI/Services/ItemBoxService/ItemBoxService.cs
@@ -33,13 +33,13 @@ public class ItemBoxService : IItemBoxService
         var query = _context.ItemsBoxs.AsQueryable();
         var filterResult = default(Expression<Func<ItemsBoxs, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_box", SearchType = "eq", Value = boxId.ToString() });
+        rsql.Add(new FilterDto { field = "id_box", search_type = "eq", value = boxId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<ItemsBoxs>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<ItemsBoxs>(sort);
             if (sortResult.Item1 != null)
@@ -48,7 +48,7 @@ public class ItemBoxService : IItemBoxService
             }
             else
             {
-                sort = new SorterDto { Field = "id_item", Order = "asc" };
+                sort = new SorterDto { field = "id_item", order = "asc" };
                 query = query.OrderBy(ib => ib.id_item);
             }
         }
@@ -74,8 +74,8 @@ public class ItemBoxService : IItemBoxService
                 offset = offset,
                 limit = limit,
                 total = await _context.ItemsBoxs.CountAsync(filterResult ?? (ib => ib.id_box == boxId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.ItemsBoxs.Skip(offset + limit).AnyAsync(filterResult ?? (ib => ib.id_box == boxId))
+                next_offset = offset + limit,
+                has_more = await _context.ItemsBoxs.Skip(offset + limit).AnyAsync(filterResult ?? (ib => ib.id_box == boxId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -93,13 +93,13 @@ public class ItemBoxService : IItemBoxService
         var query = _context.ItemsBoxs.AsQueryable();
         var filterResult = default(Expression<Func<ItemsBoxs, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_item", SearchType = "eq", Value = itemId.ToString() });
+        rsql.Add(new FilterDto { field = "id_item", search_type = "eq", value = itemId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<ItemsBoxs>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<ItemsBoxs>(sort);
             if (sortResult.Item1 != null)
@@ -108,7 +108,7 @@ public class ItemBoxService : IItemBoxService
             }
             else
             {
-                sort = new SorterDto { Field = "id_box", Order = "asc" };
+                sort = new SorterDto { field = "id_box", order = "asc" };
                 query = query.OrderBy(ib => ib.id_box);
             }
         }
@@ -134,8 +134,8 @@ public class ItemBoxService : IItemBoxService
                 offset = offset,
                 limit = limit,
                 total = await _context.ItemsBoxs.CountAsync(filterResult ?? (ib => ib.id_item == itemId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.ItemsBoxs.Skip(offset + limit).AnyAsync(filterResult ?? (ib => ib.id_item == itemId))
+                next_offset = offset + limit,
+                has_more = await _context.ItemsBoxs.Skip(offset + limit).AnyAsync(filterResult ?? (ib => ib.id_item == itemId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null

--- a/electrostoreAPI/Services/ItemDocumentService/ItemDocumentService.cs
+++ b/electrostoreAPI/Services/ItemDocumentService/ItemDocumentService.cs
@@ -33,13 +33,13 @@ public class ItemDocumentService : IItemDocumentService
         var query = _context.ItemsDocuments.AsQueryable();
         var filterResult = default(Expression<Func<ItemsDocuments, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_item", SearchType = "eq", Value = itemId.ToString() });
+        rsql.Add(new FilterDto { field = "id_item", search_type = "eq", value = itemId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<ItemsDocuments>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<ItemsDocuments>(sort);
             if (sortResult.Item1 != null)
@@ -48,7 +48,7 @@ public class ItemDocumentService : IItemDocumentService
             }
             else
             {
-                sort = new SorterDto { Field = "id_item_document", Order = "asc" };
+                sort = new SorterDto { field = "id_item_document", order = "asc" };
                 query = query.OrderBy(id => id.id_item_document);
             }
         }
@@ -66,8 +66,8 @@ public class ItemDocumentService : IItemDocumentService
                 offset = offset,
                 limit = limit,
                 total = await _context.ItemsDocuments.CountAsync(filterResult ?? (id => id.id_item == itemId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.ItemsDocuments.Skip(offset + limit).AnyAsync(filterResult ?? (id => id.id_item == itemId))
+                next_offset = offset + limit,
+                has_more = await _context.ItemsDocuments.Skip(offset + limit).AnyAsync(filterResult ?? (id => id.id_item == itemId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -97,7 +97,7 @@ public class ItemDocumentService : IItemDocumentService
             id_item = itemDocumentDto.id_item,
             url_item_document = savedFile.path,
             name_item_document = itemDocumentDto.name_item_document,
-            type_item_document = savedFile.mimeType,
+            type_item_document = savedFile.mime_type,
             size_item_document = itemDocumentDto.document.Length
         };
         await _context.ItemsDocuments.AddAsync(itemDocument);

--- a/electrostoreAPI/Services/ItemHistoryService/ItemHistoryService.cs
+++ b/electrostoreAPI/Services/ItemHistoryService/ItemHistoryService.cs
@@ -32,13 +32,13 @@ public class ItemHistoryService : IItemHistoryService
         var query = _context.ItemsHistory.AsQueryable();
         var filterResult = default(Expression<Func<ItemsHistory, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_item", SearchType = "eq", Value = itemId.ToString() });
+        rsql.Add(new FilterDto { field = "id_item", search_type = "eq", value = itemId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<ItemsHistory>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<ItemsHistory>(sort);
             if (sortResult.Item1 != null)
@@ -47,7 +47,7 @@ public class ItemHistoryService : IItemHistoryService
             }
             else
             {
-                sort = new SorterDto { Field = "id_item_history", Order = "desc" };
+                sort = new SorterDto { field = "id_item_history", order = "desc" };
                 query = query.OrderByDescending(h => h.id_item_history);
             }
         }
@@ -80,8 +80,8 @@ public class ItemHistoryService : IItemHistoryService
                 offset = offset,
                 limit = limit,
                 total = await _context.ItemsHistory.CountAsync(filterResult ?? (h => h.id_item == itemId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.ItemsHistory.Skip(offset + limit).AnyAsync(filterResult ?? (h => h.id_item == itemId))
+                next_offset = offset + limit,
+                has_more = await _context.ItemsHistory.Skip(offset + limit).AnyAsync(filterResult ?? (h => h.id_item == itemId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -120,7 +120,7 @@ public class ItemHistoryService : IItemHistoryService
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<ItemsHistory>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<ItemsHistory>(sort);
             if (sortResult.Item1 != null)
@@ -129,7 +129,7 @@ public class ItemHistoryService : IItemHistoryService
             }
             else
             {
-                sort = new SorterDto { Field = "id_item_history", Order = "desc" };
+                sort = new SorterDto { field = "id_item_history", order = "desc" };
                 query = query.OrderByDescending(h => h.id_item_history);
             }
         }
@@ -162,8 +162,8 @@ public class ItemHistoryService : IItemHistoryService
                 offset = offset,
                 limit = limit,
                 total = await _context.ItemsHistory.CountAsync(filterResult ?? (h => true)),
-                nextOffset = offset + limit,
-                hasMore = await _context.ItemsHistory.Skip(offset + limit).AnyAsync(filterResult ?? (h => true))
+                next_offset = offset + limit,
+                has_more = await _context.ItemsHistory.Skip(offset + limit).AnyAsync(filterResult ?? (h => true))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null

--- a/electrostoreAPI/Services/ItemService/ItemService.cs
+++ b/electrostoreAPI/Services/ItemService/ItemService.cs
@@ -44,7 +44,7 @@ public class ItemService : IItemService
                 (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<Items>(rsql);
                 query = query.Where(filterResult);
             }
-            if (!string.IsNullOrEmpty(sort?.Field))
+            if (!string.IsNullOrEmpty(sort?.field))
             {
                 var sortResult = RsqlParserExtensions.ToSortExpression<Items>(sort);
                 if (sortResult.Item1 != null)
@@ -53,7 +53,7 @@ public class ItemService : IItemService
                 }
                 else
                 {
-                    sort = new SorterDto { Field = "id_item", Order = "asc" };
+                    sort = new SorterDto { field = "id_item", order = "asc" };
                     query = query.OrderBy(i => i.id_item);
                 }
             }
@@ -105,8 +105,8 @@ public class ItemService : IItemService
                 offset = offset,
                 limit = limit,
                 total = await _context.Items.CountAsync(filterResult ?? (i => true)),
-                nextOffset = offset + limit,
-                hasMore = await _context.Items.Skip(offset + limit).AnyAsync(filterResult ?? (i => true))
+                next_offset = offset + limit,
+                has_more = await _context.Items.Skip(offset + limit).AnyAsync(filterResult ?? (i => true))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -174,7 +174,7 @@ public class ItemService : IItemService
                 256, 256);
             item.url_picture_item = savedImg.path;
             item.url_thumbnail_item = savedThumbnail.path;
-        await _context.SaveChangesAsync();
+            await _context.SaveChangesAsync();
         }
         await _itemHistoryService.LogHistory(item.id_item, null, ItemHistoryType.ItemCreated);
         return _mapper.Map<ReadItemDto>(item);
@@ -211,7 +211,7 @@ public class ItemService : IItemService
                 await _fileService.DeleteFile(itemToUpdate.url_picture_item);
             }
             if (itemToUpdate.url_thumbnail_item is not null)
-        {
+            {
                 await _fileService.DeleteFile(itemToUpdate.url_thumbnail_item);
             }
             itemToUpdate.url_picture_item = null;

--- a/electrostoreAPI/Services/ItemTagService/ItemTagService.cs
+++ b/electrostoreAPI/Services/ItemTagService/ItemTagService.cs
@@ -29,13 +29,13 @@ public class ItemTagService : IItemTagService
         var query = _context.ItemsTags.AsQueryable();
         var filterResult = default(Expression<Func<ItemsTags, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_item", SearchType = "eq", Value = itemId.ToString() });
+        rsql.Add(new FilterDto { field = "id_item", search_type = "eq", value = itemId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<ItemsTags>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<ItemsTags>(sort);
             if (sortResult.Item1 != null)
@@ -44,7 +44,7 @@ public class ItemTagService : IItemTagService
             }
             else
             {
-                sort = new SorterDto { Field = "id_tag", Order = "asc" };
+                sort = new SorterDto { field = "id_tag", order = "asc" };
                 query = query.OrderBy(it => it.id_tag);
             }
         }
@@ -70,8 +70,8 @@ public class ItemTagService : IItemTagService
                 offset = offset,
                 limit = limit,
                 total = await _context.ItemsTags.CountAsync(filterResult ?? (it => it.id_item == itemId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.ItemsTags.Skip(offset + limit).AnyAsync(filterResult ?? (it => it.id_item == itemId))
+                next_offset = offset + limit,
+                has_more = await _context.ItemsTags.Skip(offset + limit).AnyAsync(filterResult ?? (it => it.id_item == itemId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -89,13 +89,13 @@ public class ItemTagService : IItemTagService
         var query = _context.ItemsTags.AsQueryable();
         var filterResult = default(Expression<Func<ItemsTags, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_tag", SearchType = "eq", Value = tagId.ToString() });
+        rsql.Add(new FilterDto { field = "id_tag", search_type = "eq", value = tagId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<ItemsTags>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<ItemsTags>(sort);
             if (sortResult.Item1 != null)
@@ -104,7 +104,7 @@ public class ItemTagService : IItemTagService
             }
             else
             {
-                sort = new SorterDto { Field = "id_item", Order = "asc" };
+                sort = new SorterDto { field = "id_item", order = "asc" };
                 query = query.OrderBy(it => it.id_item);
             }
         }
@@ -130,8 +130,8 @@ public class ItemTagService : IItemTagService
                 offset = offset,
                 limit = limit,
                 total = await _context.ItemsTags.CountAsync(filterResult ?? (it => it.id_tag == tagId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.ItemsTags.Skip(offset + limit).AnyAsync(filterResult ?? (it => it.id_tag == tagId))
+                next_offset = offset + limit,
+                has_more = await _context.ItemsTags.Skip(offset + limit).AnyAsync(filterResult ?? (it => it.id_tag == tagId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -191,15 +191,15 @@ public class ItemTagService : IItemTagService
             {
                 errorQuery.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = itemTagDto
+                    reason = e.Message,
+                    data = itemTagDto
                 });
             }
         }
         return new ReadBulkItemTagDto
         {
-            Valide = validQuery,
-            Error = errorQuery
+            valide = validQuery,
+            error = errorQuery
         };
     }
 
@@ -229,15 +229,15 @@ public class ItemTagService : IItemTagService
             {
                 errorQuery.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = itemTagDto
+                    reason = e.Message,
+                    data = itemTagDto
                 });
             }
         }
         return new ReadBulkItemTagDto
         {
-            Valide = validQuery,
-            Error = errorQuery
+            valide = validQuery,
+            error = errorQuery
         };
     }
 }

--- a/electrostoreAPI/Services/JwiService/JwiService.cs
+++ b/electrostoreAPI/Services/JwiService/JwiService.cs
@@ -158,13 +158,13 @@ public class JwiService : IJwiService
         var query = _context.JwiRefreshTokens.AsQueryable();
         var filterResult = default(Expression<Func<JwiRefreshTokens, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_user", SearchType = "eq", Value = userId.ToString() });
+        rsql.Add(new FilterDto { field = "id_user", search_type = "eq", value = userId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<JwiRefreshTokens>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<JwiRefreshTokens>(sort);
             if (sortResult.Item1 != null)
@@ -173,7 +173,7 @@ public class JwiService : IJwiService
             }
             else
             {
-                sort = new SorterDto { Field = "created_at", Order = "desc" };
+                sort = new SorterDto { field = "created_at", order = "desc" };
                 query = query.OrderByDescending(jwi => jwi.created_at);
             }
         }
@@ -207,8 +207,8 @@ public class JwiService : IJwiService
                 offset = offset,
                 limit = limit,
                 total = await query.Select(jwi => jwi.session_id_jwi_refresh).Distinct().CountAsync(),
-                nextOffset = offset + limit,
-                hasMore = await query.Select(jwi => jwi.session_id_jwi_refresh).Distinct().Skip(offset + limit).AnyAsync()
+                next_offset = offset + limit,
+                has_more = await query.Select(jwi => jwi.session_id_jwi_refresh).Distinct().Skip(offset + limit).AnyAsync()
             },
             filters = rsql,
             sort = sort != null ? [sort] : null

--- a/electrostoreAPI/Services/LedService/LedService.cs
+++ b/electrostoreAPI/Services/LedService/LedService.cs
@@ -42,13 +42,13 @@ public class LedService : ILedService
         var query = _context.Leds.AsQueryable();
         var filterResult = default(Expression<Func<Leds, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_store", SearchType = "eq", Value = storeId.ToString() });
+        rsql.Add(new FilterDto { field = "id_store", search_type = "eq", value = storeId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<Leds>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<Leds>(sort);
             if (sortResult.Item1 != null)
@@ -57,7 +57,7 @@ public class LedService : ILedService
             }
             else
             {
-                sort = new SorterDto { Field = "id_led", Order = "asc" };
+                sort = new SorterDto { field = "id_led", order = "asc" };
                 query = query.OrderBy(l => l.id_led);
             }
         }
@@ -75,8 +75,8 @@ public class LedService : ILedService
                 offset = offset,
                 limit = limit,
                 total = await _context.Leds.CountAsync(filterResult ?? (l => l.id_store == storeId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.Leds.Skip(offset + limit).AnyAsync(filterResult ?? (l => l.id_store == storeId))
+                next_offset = offset + limit,
+                has_more = await _context.Leds.Skip(offset + limit).AnyAsync(filterResult ?? (l => l.id_store == storeId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -132,15 +132,15 @@ public class LedService : ILedService
             {
                 errorQuery.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = ledDto
+                    reason = e.Message,
+                    data = ledDto
                 });
             }
         }
         return new ReadBulkLedDto
         {
-            Valide = validQuery,
-            Error = errorQuery
+            valide = validQuery,
+            error = errorQuery
         };
     }
 
@@ -188,15 +188,15 @@ public class LedService : ILedService
             {
                 errorQuery.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = ledDto
+                    reason = e.Message,
+                    data = ledDto
                 });
             }
         }
         return new ReadBulkLedDto
         {
-            Valide = validQuery,
-            Error = errorQuery
+            valide = validQuery,
+            error = errorQuery
         };
     }
 
@@ -239,15 +239,15 @@ public class LedService : ILedService
             {
                 errorQuery.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = new { id }
+                    reason = e.Message,
+                    data = new { id }
                 });
             }
         }
         return new ReadBulkLedDto
         {
-            Valide = validQuery,
-            Error = errorQuery
+            valide = validQuery,
+            error = errorQuery
         };
     }
 

--- a/electrostoreAPI/Services/ProjectCommentService/ProjectCommentService.cs
+++ b/electrostoreAPI/Services/ProjectCommentService/ProjectCommentService.cs
@@ -33,13 +33,13 @@ public class ProjectCommentService : IProjectCommentService
         var query = _context.ProjectsComments.AsQueryable();
         var filterResult = default(Expression<Func<ProjectsComments, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_project", SearchType = "eq", Value = projectId.ToString() });
+        rsql.Add(new FilterDto { field = "id_project", search_type = "eq", value = projectId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<ProjectsComments>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<ProjectsComments>(sort);
             if (sortResult.Item1 != null)
@@ -48,7 +48,7 @@ public class ProjectCommentService : IProjectCommentService
             }
             else
             {
-                sort = new SorterDto { Field = "created_at", Order = "desc" };
+                sort = new SorterDto { field = "created_at", order = "desc" };
                 query = query.OrderByDescending(p => p.created_at);
             }
         }
@@ -74,8 +74,8 @@ public class ProjectCommentService : IProjectCommentService
                 offset = offset,
                 limit = limit,
                 total = await _context.ProjectsComments.CountAsync(filterResult ?? (pc => pc.id_project == projectId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.ProjectsComments.Skip(offset + limit).AnyAsync(filterResult ?? (pc => pc.id_project == projectId))
+                next_offset = offset + limit,
+                has_more = await _context.ProjectsComments.Skip(offset + limit).AnyAsync(filterResult ?? (pc => pc.id_project == projectId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -93,13 +93,13 @@ public class ProjectCommentService : IProjectCommentService
         var query = _context.ProjectsComments.AsQueryable();
         var filterResult = default(Expression<Func<ProjectsComments, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_user", SearchType = "eq", Value = userId.ToString() });
+        rsql.Add(new FilterDto { field = "id_user", search_type = "eq", value = userId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<ProjectsComments>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<ProjectsComments>(sort);
             if (sortResult.Item1 != null)
@@ -108,7 +108,7 @@ public class ProjectCommentService : IProjectCommentService
             }
             else
             {
-                sort = new SorterDto { Field = "created_at", Order = "desc" };
+                sort = new SorterDto { field = "created_at", order = "desc" };
                 query = query.OrderByDescending(p => p.created_at);
             }
         }
@@ -134,8 +134,8 @@ public class ProjectCommentService : IProjectCommentService
                 offset = offset,
                 limit = limit,
                 total = await _context.ProjectsComments.CountAsync(filterResult ?? (pc => pc.id_user == userId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.ProjectsComments.Skip(offset + limit).AnyAsync(filterResult ?? (pc => pc.id_user == userId))
+                next_offset = offset + limit,
+                has_more = await _context.ProjectsComments.Skip(offset + limit).AnyAsync(filterResult ?? (pc => pc.id_user == userId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null

--- a/electrostoreAPI/Services/ProjectDocumentService/ProjectDocumentService.cs
+++ b/electrostoreAPI/Services/ProjectDocumentService/ProjectDocumentService.cs
@@ -33,13 +33,13 @@ public class ProjectDocumentService : IProjectDocumentService
         var query = _context.ProjectsDocuments.AsQueryable();
         var filterResult = default(Expression<Func<ProjectsDocuments, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_project", SearchType = "eq", Value = projectId.ToString() });
+        rsql.Add(new FilterDto { field = "id_project", search_type = "eq", value = projectId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<ProjectsDocuments>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<ProjectsDocuments>(sort);
             if (sortResult.Item1 != null)
@@ -48,7 +48,7 @@ public class ProjectDocumentService : IProjectDocumentService
             }
             else
             {
-                sort = new SorterDto { Field = "id_project_document", Order = "asc" };
+                sort = new SorterDto { field = "id_project_document", order = "asc" };
                 query = query.OrderBy(pd => pd.id_project_document);
             }
         }
@@ -66,8 +66,8 @@ public class ProjectDocumentService : IProjectDocumentService
                 offset = offset,
                 limit = limit,
                 total = await _context.ProjectsDocuments.CountAsync(filterResult ?? (pd => pd.id_project == projectId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.ProjectsDocuments.Skip(offset + limit).AnyAsync(filterResult ?? (pd => pd.id_project == projectId))
+                next_offset = offset + limit,
+                has_more = await _context.ProjectsDocuments.Skip(offset + limit).AnyAsync(filterResult ?? (pd => pd.id_project == projectId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -97,7 +97,7 @@ public class ProjectDocumentService : IProjectDocumentService
             id_project = projectDocumentDto.id_project,
             url_project_document = savedFile.path,
             name_project_document = projectDocumentDto.name_project_document,
-            type_project_document = savedFile.mimeType,
+            type_project_document = savedFile.mime_type,
             size_project_document = projectDocumentDto.document.Length
         };
         await _context.ProjectsDocuments.AddAsync(projectDocument);

--- a/electrostoreAPI/Services/ProjectItemService/ProjectItemService.cs
+++ b/electrostoreAPI/Services/ProjectItemService/ProjectItemService.cs
@@ -29,13 +29,13 @@ public class ProjectItemService : IProjectItemService
         var query = _context.ProjectsItems.AsQueryable();
         var filterResult = default(Expression<Func<ProjectsItems, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_project", SearchType = "eq", Value = projectId.ToString() });
+        rsql.Add(new FilterDto { field = "id_project", search_type = "eq", value = projectId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<ProjectsItems>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<ProjectsItems>(sort);
             if (sortResult.Item1 != null)
@@ -44,7 +44,7 @@ public class ProjectItemService : IProjectItemService
             }
             else
             {
-                sort = new SorterDto { Field = "id_item", Order = "asc" };
+                sort = new SorterDto { field = "id_item", order = "asc" };
                 query = query.OrderBy(pi => pi.id_item);
             }
         }
@@ -70,8 +70,8 @@ public class ProjectItemService : IProjectItemService
                 offset = offset,
                 limit = limit,
                 total = await _context.ProjectsItems.CountAsync(filterResult ?? (pi => pi.id_project == projectId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.ProjectsItems.Skip(offset + limit).AnyAsync(filterResult ?? (pi => pi.id_project == projectId))
+                next_offset = offset + limit,
+                has_more = await _context.ProjectsItems.Skip(offset + limit).AnyAsync(filterResult ?? (pi => pi.id_project == projectId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -89,13 +89,13 @@ public class ProjectItemService : IProjectItemService
         var query = _context.ProjectsItems.AsQueryable();
         var filterResult = default(Expression<Func<ProjectsItems, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_item", SearchType = "eq", Value = itemId.ToString() });
+        rsql.Add(new FilterDto { field = "id_item", search_type = "eq", value = itemId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<ProjectsItems>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<ProjectsItems>(sort);
             if (sortResult.Item1 != null)
@@ -104,7 +104,7 @@ public class ProjectItemService : IProjectItemService
             }
             else
             {
-                sort = new SorterDto { Field = "id_project", Order = "asc" };
+                sort = new SorterDto { field = "id_project", order = "asc" };
                 query = query.OrderBy(pi => pi.id_project);
             }
         }
@@ -130,8 +130,8 @@ public class ProjectItemService : IProjectItemService
                 offset = offset,
                 limit = limit,
                 total = await _context.ProjectsItems.CountAsync(filterResult ?? (pi => pi.id_item == itemId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.ProjectsItems.Skip(offset + limit).AnyAsync(filterResult ?? (pi => pi.id_item == itemId))
+                next_offset = offset + limit,
+                has_more = await _context.ProjectsItems.Skip(offset + limit).AnyAsync(filterResult ?? (pi => pi.id_item == itemId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -191,15 +191,15 @@ public class ProjectItemService : IProjectItemService
             {
                 errorQuery.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = projectItemDto
+                    reason = e.Message,
+                    data = projectItemDto
                 });
             }
         }
         return new ReadBulkProjectItemDto
         {
-            Valide = validQuery,
-            Error = errorQuery
+            valide = validQuery,
+            error = errorQuery
         };
     }
 

--- a/electrostoreAPI/Services/ProjectProjectTagService/ProjectProjectTagService.cs
+++ b/electrostoreAPI/Services/ProjectProjectTagService/ProjectProjectTagService.cs
@@ -33,13 +33,13 @@ public class ProjectProjectTagService : IProjectProjectTagService
         var query = _context.ProjectsProjectTags.AsQueryable();
         var filterResult = default(Expression<Func<ProjectsProjectTags, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_project", SearchType = "eq", Value = projectId.ToString() });
+        rsql.Add(new FilterDto { field = "id_project", search_type = "eq", value = projectId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<ProjectsProjectTags>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<ProjectsProjectTags>(sort);
             if (sortResult.Item1 != null)
@@ -48,7 +48,7 @@ public class ProjectProjectTagService : IProjectProjectTagService
             }
             else
             {
-                sort = new SorterDto { Field = "id_project_tag", Order = "asc" };
+                sort = new SorterDto { field = "id_project_tag", order = "asc" };
                 query = query.OrderBy(st => st.id_project_tag);
             }
         }
@@ -74,8 +74,8 @@ public class ProjectProjectTagService : IProjectProjectTagService
                 offset = offset,
                 limit = limit,
                 total = await _context.ProjectsProjectTags.CountAsync(filterResult ?? (st => st.id_project == projectId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.ProjectsProjectTags.Skip(offset + limit).AnyAsync(filterResult ?? (st => st.id_project == projectId))
+                next_offset = offset + limit,
+                has_more = await _context.ProjectsProjectTags.Skip(offset + limit).AnyAsync(filterResult ?? (st => st.id_project == projectId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -93,13 +93,13 @@ public class ProjectProjectTagService : IProjectProjectTagService
         var query = _context.ProjectsProjectTags.AsQueryable();
         var filterResult = default(Expression<Func<ProjectsProjectTags, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_project_tag", SearchType = "eq", Value = projectTagId.ToString() });
+        rsql.Add(new FilterDto { field = "id_project_tag", search_type = "eq", value = projectTagId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<ProjectsProjectTags>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<ProjectsProjectTags>(sort);
             if (sortResult.Item1 != null)
@@ -108,7 +108,7 @@ public class ProjectProjectTagService : IProjectProjectTagService
             }
             else
             {
-                sort = new SorterDto { Field = "id_project", Order = "asc" };
+                sort = new SorterDto { field = "id_project", order = "asc" };
                 query = query.OrderBy(st => st.id_project);
             }
         }
@@ -134,8 +134,8 @@ public class ProjectProjectTagService : IProjectProjectTagService
                 offset = offset,
                 limit = limit,
                 total = await _context.ProjectsProjectTags.CountAsync(filterResult ?? (st => st.id_project_tag == projectTagId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.ProjectsProjectTags.Skip(offset + limit).AnyAsync(filterResult ?? (st => st.id_project_tag == projectTagId))
+                next_offset = offset + limit,
+                has_more = await _context.ProjectsProjectTags.Skip(offset + limit).AnyAsync(filterResult ?? (st => st.id_project_tag == projectTagId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -205,15 +205,15 @@ public class ProjectProjectTagService : IProjectProjectTagService
             {
                 errorQuery.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = projectProjectTagDto
+                    reason = e.Message,
+                    data = projectProjectTagDto
                 });
             }
         }
         return new ReadBulkProjectProjectTagDto
         {
-            Valide = validQuery,
-            Error = errorQuery
+            valide = validQuery,
+            error = errorQuery
         };
     }
 
@@ -253,16 +253,16 @@ public class ProjectProjectTagService : IProjectProjectTagService
             {
                 errorQuery.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = projectProjectTagDto
+                    reason = e.Message,
+                    data = projectProjectTagDto
                 });
             }
         }
         await _context.SaveChangesAsync();
         return new ReadBulkProjectProjectTagDto
         {
-            Valide = validQuery,
-            Error = errorQuery
+            valide = validQuery,
+            error = errorQuery
         };
     }
 }

--- a/electrostoreAPI/Services/ProjectService/ProjectService.cs
+++ b/electrostoreAPI/Services/ProjectService/ProjectService.cs
@@ -42,7 +42,7 @@ public class ProjectService : IProjectService
                 (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<Projects>(rsql);
                 query = query.Where(filterResult);
             }
-            if (!string.IsNullOrEmpty(sort?.Field))
+            if (!string.IsNullOrEmpty(sort?.field))
             {
                 var sortResult = RsqlParserExtensions.ToSortExpression<Projects>(sort);
                 if (sortResult.Item1 != null)
@@ -51,7 +51,7 @@ public class ProjectService : IProjectService
                 }
                 else
                 {
-                    sort = new SorterDto { Field = "id_project", Order = "asc" };
+                    sort = new SorterDto { field = "id_project", order = "asc" };
                     query = query.OrderBy(p => p.id_project);
                 }
             }
@@ -111,8 +111,8 @@ public class ProjectService : IProjectService
                 offset = offset,
                 limit = limit,
                 total = await _context.Projects.CountAsync(filterResult ?? (p => true)),
-                nextOffset = offset + limit,
-                hasMore = await _context.Projects.Skip(offset + limit).AnyAsync(filterResult ?? (p => true))
+                next_offset = offset + limit,
+                has_more = await _context.Projects.Skip(offset + limit).AnyAsync(filterResult ?? (p => true))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null

--- a/electrostoreAPI/Services/ProjectStatusService/ProjectStatusService.cs
+++ b/electrostoreAPI/Services/ProjectStatusService/ProjectStatusService.cs
@@ -27,14 +27,14 @@ public class ProjectStatusService : IProjectStatusService
         }
         var query = _context.ProjectsStatus.AsQueryable();
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_project", SearchType = "eq", Value = projectId.ToString() });
+        rsql.Add(new FilterDto { field = "id_project", search_type = "eq", value = projectId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             var filterResult = RsqlParserExtensions.ToFilterExpression<ProjectsStatus>(rsql);
             query = query.Where(filterResult.Item1);
             rsql = filterResult.Item2;
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<ProjectsStatus>(sort);
             if (sortResult.Item1 != null)
@@ -43,7 +43,7 @@ public class ProjectStatusService : IProjectStatusService
             }
             else
             {
-                sort = new SorterDto { Field = "created_at", Order = "desc" };
+                sort = new SorterDto { field = "created_at", order = "desc" };
                 query = query.OrderByDescending(p => p.created_at);
             }
         }
@@ -61,8 +61,8 @@ public class ProjectStatusService : IProjectStatusService
                 offset = offset,
                 limit = limit,
                 total = await _context.ProjectsStatus.CountAsync(p => p.id_project == projectId),
-                nextOffset = offset + limit,
-                hasMore = await _context.ProjectsStatus.Skip(offset + limit).AnyAsync(p => p.id_project == projectId)
+                next_offset = offset + limit,
+                has_more = await _context.ProjectsStatus.Skip(offset + limit).AnyAsync(p => p.id_project == projectId)
             },
             filters = rsql,
             sort = sort != null ? [sort] : null

--- a/electrostoreAPI/Services/ProjectTagService/ProjectTagService.cs
+++ b/electrostoreAPI/Services/ProjectTagService/ProjectTagService.cs
@@ -34,7 +34,7 @@ public class ProjectTagService : IProjectTagService
                 (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<ProjectTags>(rsql);
                 query = query.Where(filterResult);
             }
-            if (!string.IsNullOrEmpty(sort?.Field))
+            if (!string.IsNullOrEmpty(sort?.field))
             {
                 var sortResult = RsqlParserExtensions.ToSortExpression<ProjectTags>(sort);
                 if (sortResult.Item1 != null)
@@ -43,7 +43,7 @@ public class ProjectTagService : IProjectTagService
                 }
                 else
                 {
-                    sort = new SorterDto { Field = "id_project_tag", Order = "asc" };
+                    sort = new SorterDto { field = "id_project_tag", order = "asc" };
                     query = query.OrderBy(t => t.id_project_tag);
                 }
             }
@@ -73,8 +73,8 @@ public class ProjectTagService : IProjectTagService
                 offset = offset,
                 limit = limit,
                 total = await _context.ProjectTags.CountAsync(filterResult ?? (t => true)),
-                nextOffset = offset + limit,
-                hasMore = await _context.ProjectTags.Skip(offset + limit).AnyAsync(filterResult ?? (t => true))
+                next_offset = offset + limit,
+                has_more = await _context.ProjectTags.Skip(offset + limit).AnyAsync(filterResult ?? (t => true))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -127,15 +127,15 @@ public class ProjectTagService : IProjectTagService
             {
                 errorQuery.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = projectTagDto
+                    reason = e.Message,
+                    data = projectTagDto
                 });
             }
         }
         return new ReadBulkProjectTagDto
         {
-            Valide = validQuery,
-            Error = errorQuery
+            valide = validQuery,
+            error = errorQuery
         };
     }
 

--- a/electrostoreAPI/Services/StatusService/StatusService.cs
+++ b/electrostoreAPI/Services/StatusService/StatusService.cs
@@ -58,7 +58,7 @@ public class StatusService : IStatusService
             ai_training_in_progress = aiHealth.TryGetValue("training_in_progress", out var trainingElement) && trainingElement.ValueKind == JsonValueKind.Number && trainingElement.TryGetInt32(out var trainingCount) ? trainingCount : 0,
             notif_status = notifHealth.TryGetValue("status", out var notifStatus) && notifStatus.GetString() is string ns ? ns : "unknown",
             notif_smtp = notifHealth.TryGetValue("smtp", out var smtpElement) && (smtpElement.ValueKind == JsonValueKind.True || smtpElement.ValueKind == JsonValueKind.False) ? smtpElement.ValueKind == JsonValueKind.True : (bool?)false,
-            notif_webPush = notifHealth.TryGetValue("webPush", out var wpElement) && (wpElement.ValueKind == JsonValueKind.True || wpElement.ValueKind == JsonValueKind.False) ? wpElement.ValueKind == JsonValueKind.True : (bool?)false,
+            notif_web_push = notifHealth.TryGetValue("webPush", out var wpElement) && (wpElement.ValueKind == JsonValueKind.True || wpElement.ValueKind == JsonValueKind.False) ? wpElement.ValueKind == JsonValueKind.True : (bool?)false,
             cron_status = cronHealth.TryGetValue("status", out var cronStatus) && cronStatus.GetString() is string cs ? cs : "unknown",
             worker_status = workerHealth.TryGetValue("status", out var workerStatus) && workerStatus.GetString() is string workerStr ? workerStr : "unknown",
             external_services = new Dictionary<string, string>

--- a/electrostoreAPI/Services/StoreService/StoreService.cs
+++ b/electrostoreAPI/Services/StoreService/StoreService.cs
@@ -52,7 +52,7 @@ public class StoreService : IStoreService
                 (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<Stores>(rsql);
                 query = query.Where(filterResult);
             }
-            if (!string.IsNullOrEmpty(sort?.Field))
+            if (!string.IsNullOrEmpty(sort?.field))
             {
                 var sortResult = RsqlParserExtensions.ToSortExpression<Stores>(sort);
                 if (sortResult.Item1 != null)
@@ -61,7 +61,7 @@ public class StoreService : IStoreService
                 }
                 else
                 {
-                    sort = new SorterDto { Field = "id_store", Order = "asc" };
+                    sort = new SorterDto { field = "id_store", order = "asc" };
                     query = query.OrderBy(s => s.id_store);
                 }
             }
@@ -106,8 +106,8 @@ public class StoreService : IStoreService
                 offset = offset,
                 limit = limit,
                 total = await _context.Stores.CountAsync(filterResult ?? (s => true)),
-                nextOffset = offset + limit,
-                hasMore = await _context.Stores.Skip(offset + limit).AnyAsync(filterResult ?? (s => true))
+                next_offset = offset + limit,
+                has_more = await _context.Stores.Skip(offset + limit).AnyAsync(filterResult ?? (s => true))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -137,9 +137,9 @@ public class StoreService : IStoreService
         {
             mqttPassword = await _encryptionService.Decrypt(new EncryptDto
             {
-                EncryptedData = store.Store.mqtt_password_store,
-                IV = store.Store.mqtt_password_encryption_iv_store,
-                Tag = store.Store.mqtt_password_encryption_tag_store
+                encrypted_data = store.Store.mqtt_password_store,
+                iv = store.Store.mqtt_password_encryption_iv_store,
+                tag = store.Store.mqtt_password_encryption_tag_store
             }, _encryptionKey);
         }
         return _mapper.Map<ReadExtendedStoreDto>(store.Store) with
@@ -178,9 +178,9 @@ public class StoreService : IStoreService
         await _validateStoreService.ValidateStorePlanPosition(newStore);
         var mqttPassword = GenerateMqttPasswordForStore();
         var encryptedPassword = await _encryptionService.Encrypt(mqttPassword, _encryptionKey);
-        newStore.mqtt_password_store = encryptedPassword.EncryptedData;
-        newStore.mqtt_password_encryption_iv_store = encryptedPassword.IV;
-        newStore.mqtt_password_encryption_tag_store = encryptedPassword.Tag;
+        newStore.mqtt_password_store = encryptedPassword.encrypted_data;
+        newStore.mqtt_password_encryption_iv_store = encryptedPassword.iv;
+        newStore.mqtt_password_encryption_tag_store = encryptedPassword.tag;
         _context.Stores.Add(newStore);
         await _context.SaveChangesAsync();
         await _kafkaProducer.PublishAsync(
@@ -216,9 +216,9 @@ public class StoreService : IStoreService
         {
             mqttPassword = GenerateMqttPasswordForStore();
             var encryptedPassword = await _encryptionService.Encrypt(mqttPassword, _encryptionKey);
-            storeToUpdate.mqtt_password_store = encryptedPassword.EncryptedData;
-            storeToUpdate.mqtt_password_encryption_iv_store = encryptedPassword.IV;
-            storeToUpdate.mqtt_password_encryption_tag_store = encryptedPassword.Tag;
+            storeToUpdate.mqtt_password_store = encryptedPassword.encrypted_data;
+            storeToUpdate.mqtt_password_encryption_iv_store = encryptedPassword.iv;
+            storeToUpdate.mqtt_password_encryption_tag_store = encryptedPassword.tag;
             await _kafkaProducer.PublishAsync(
                 "mqtt-user-events",
                 storeToUpdate.id_store.ToString(),
@@ -236,9 +236,9 @@ public class StoreService : IStoreService
         {
             mqttPassword = await _encryptionService.Decrypt(new EncryptDto
             {
-                EncryptedData = storeToUpdate.mqtt_password_store,
-                IV = storeToUpdate.mqtt_password_encryption_iv_store,
-                Tag = storeToUpdate.mqtt_password_encryption_tag_store
+                encrypted_data = storeToUpdate.mqtt_password_store,
+                iv = storeToUpdate.mqtt_password_encryption_iv_store,
+                tag = storeToUpdate.mqtt_password_encryption_tag_store
             }, _encryptionKey);
         }
         return _mapper.Map<ReadStoreDto>(storeToUpdate) with
@@ -315,8 +315,8 @@ public class StoreService : IStoreService
             {
                 errorQueryLed.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = ledDto
+                    reason = e.Message,
+                    data = ledDto
                 });
             }
         }
@@ -344,16 +344,16 @@ public class StoreService : IStoreService
             {
                 errorQueryBox.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = boxDto
+                    reason = e.Message,
+                    data = boxDto
                 });
             }
         }
         var mqttPassword = GenerateMqttPasswordForStore();
         var encryptedPassword = await _encryptionService.Encrypt(mqttPassword, _encryptionKey);
-        newStore.mqtt_password_store = encryptedPassword.EncryptedData;
-        newStore.mqtt_password_encryption_iv_store = encryptedPassword.IV;
-        newStore.mqtt_password_encryption_tag_store = encryptedPassword.Tag;
+        newStore.mqtt_password_store = encryptedPassword.encrypted_data;
+        newStore.mqtt_password_encryption_iv_store = encryptedPassword.iv;
+        newStore.mqtt_password_encryption_tag_store = encryptedPassword.tag;
         await _context.SaveChangesAsync();
         if (errorQueryLed.Count == 0 && errorQueryBox.Count == 0)
         {
@@ -382,13 +382,13 @@ public class StoreService : IStoreService
             },
             leds = new ReadBulkLedDto
             {
-                Valide = validQueryLed,
-                Error = errorQueryLed
+                valide = validQueryLed,
+                error = errorQueryLed
             },
             boxs = new ReadBulkBoxDto
             {
-                Valide = validQueryBox,
-                Error = errorQueryBox
+                valide = validQueryBox,
+                error = errorQueryBox
             }
         };
     }
@@ -426,8 +426,8 @@ public class StoreService : IStoreService
                 {
                     errorQueryBox.Add(new ErrorDetail
                     {
-                        Reason = e.Message,
-                        Data = box
+                        reason = e.Message,
+                        data = box
                     });
                 }
             }
@@ -440,9 +440,9 @@ public class StoreService : IStoreService
             {
                 mqttPassword = GenerateMqttPasswordForStore();
                 var encryptedPassword = await _encryptionService.Encrypt(mqttPassword, _encryptionKey);
-                storeToUpdate.mqtt_password_store = encryptedPassword.EncryptedData;
-                storeToUpdate.mqtt_password_encryption_iv_store = encryptedPassword.IV;
-                storeToUpdate.mqtt_password_encryption_tag_store = encryptedPassword.Tag;
+                storeToUpdate.mqtt_password_store = encryptedPassword.encrypted_data;
+                storeToUpdate.mqtt_password_encryption_iv_store = encryptedPassword.iv;
+                storeToUpdate.mqtt_password_encryption_tag_store = encryptedPassword.tag;
                 await _context.SaveChangesAsync();
                 await _kafkaProducer.PublishAsync(
                     "mqtt-user-events",
@@ -466,9 +466,9 @@ public class StoreService : IStoreService
         {
             mqttPassword = await _encryptionService.Decrypt(new EncryptDto
             {
-                EncryptedData = storeToUpdate.mqtt_password_store,
-                IV = storeToUpdate.mqtt_password_encryption_iv_store,
-                Tag = storeToUpdate.mqtt_password_encryption_tag_store
+                encrypted_data = storeToUpdate.mqtt_password_store,
+                iv = storeToUpdate.mqtt_password_encryption_iv_store,
+                tag = storeToUpdate.mqtt_password_encryption_tag_store
             }, _encryptionKey);
         }
         return new ReadStoreCompleteDto
@@ -479,13 +479,13 @@ public class StoreService : IStoreService
             },
             leds = new ReadBulkLedDto
             {
-                Valide = validQueryLed,
-                Error = errorQueryLed
+                valide = validQueryLed,
+                error = errorQueryLed
             },
             boxs = new ReadBulkBoxDto
             {
-                Valide = validQueryBox,
-                Error = errorQueryBox
+                valide = validQueryBox,
+                error = errorQueryBox
             }
         };
     }
@@ -563,8 +563,8 @@ public class StoreService : IStoreService
             {
                 errorQueryLed.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = led
+                    reason = e.Message,
+                    data = led
                 });
             }
         }
@@ -620,8 +620,8 @@ public class StoreService : IStoreService
             {
                 errorQueryBox.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = box
+                    reason = e.Message,
+                    data = box
                 });
             }
         }

--- a/electrostoreAPI/Services/StoreTagService/StoreTagService.cs
+++ b/electrostoreAPI/Services/StoreTagService/StoreTagService.cs
@@ -33,13 +33,13 @@ public class StoreTagService : IStoreTagService
         var query = _context.StoresTags.AsQueryable();
         var filterResult = default(Expression<Func<StoresTags, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_store", SearchType = "eq", Value = storeId.ToString() });
+        rsql.Add(new FilterDto { field = "id_store", search_type = "eq", value = storeId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<StoresTags>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<StoresTags>(sort);
             if (sortResult.Item1 != null)
@@ -48,7 +48,7 @@ public class StoreTagService : IStoreTagService
             }
             else
             {
-                sort = new SorterDto { Field = "id_tag", Order = "asc" };
+                sort = new SorterDto { field = "id_tag", order = "asc" };
                 query = query.OrderBy(st => st.id_tag);
             }
         }
@@ -74,8 +74,8 @@ public class StoreTagService : IStoreTagService
                 offset = offset,
                 limit = limit,
                 total = await _context.StoresTags.CountAsync(filterResult ?? ( st => st.id_store == storeId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.StoresTags.Skip(offset + limit).AnyAsync(filterResult ?? (st => st.id_store == storeId))
+                next_offset = offset + limit,
+                has_more = await _context.StoresTags.Skip(offset + limit).AnyAsync(filterResult ?? (st => st.id_store == storeId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -93,13 +93,13 @@ public class StoreTagService : IStoreTagService
         var query = _context.StoresTags.AsQueryable();
         var filterResult = default(Expression<Func<StoresTags, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_tag", SearchType = "eq", Value = tagId.ToString() });
+        rsql.Add(new FilterDto { field = "id_tag", search_type = "eq", value = tagId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<StoresTags>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<StoresTags>(sort);
             if (sortResult.Item1 != null)
@@ -108,7 +108,7 @@ public class StoreTagService : IStoreTagService
             }
             else
             {
-                sort = new SorterDto { Field = "id_store", Order = "asc" };
+                sort = new SorterDto { field = "id_store", order = "asc" };
                 query = query.OrderBy(st => st.id_store);
             }
         }
@@ -134,8 +134,8 @@ public class StoreTagService : IStoreTagService
                 offset = offset,
                 limit = limit,
                 total = await _context.StoresTags.CountAsync(filterResult ?? (st => st.id_tag == tagId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.StoresTags.Skip(offset + limit).AnyAsync(filterResult ?? (st => st.id_tag == tagId))
+                next_offset = offset + limit,
+                has_more = await _context.StoresTags.Skip(offset + limit).AnyAsync(filterResult ?? (st => st.id_tag == tagId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -205,15 +205,15 @@ public class StoreTagService : IStoreTagService
             {
                 errorQuery.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = storeTagDto
+                    reason = e.Message,
+                    data = storeTagDto
                 });
             }
         }
         return new ReadBulkStoreTagDto
         {
-            Valide = validQuery,
-            Error = errorQuery
+            valide = validQuery,
+            error = errorQuery
         };
     }
 
@@ -253,16 +253,16 @@ public class StoreTagService : IStoreTagService
             {
                 errorQuery.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = storeTagDto
+                    reason = e.Message,
+                    data = storeTagDto
                 });
             }
         }
         await _context.SaveChangesAsync();
         return new ReadBulkStoreTagDto
         {
-            Valide = validQuery,
-            Error = errorQuery
+            valide = validQuery,
+            error = errorQuery
         };
     }
 }

--- a/electrostoreAPI/Services/TagService/TagService.cs
+++ b/electrostoreAPI/Services/TagService/TagService.cs
@@ -34,7 +34,7 @@ public class TagService : ITagService
                 (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<Tags>(rsql);
                 query = query.Where(filterResult);
             }
-            if (!string.IsNullOrEmpty(sort?.Field))
+            if (!string.IsNullOrEmpty(sort?.field))
             {
                 var sortResult = RsqlParserExtensions.ToSortExpression<Tags>(sort);
                 if (sortResult.Item1 != null)
@@ -43,7 +43,7 @@ public class TagService : ITagService
                 }
                 else
                 {
-                    sort = new SorterDto { Field = "id_tag", Order = "asc" };
+                    sort = new SorterDto { field = "id_tag", order = "asc" };
                     query = query.OrderBy(t => t.id_tag);
                 }
             }
@@ -83,8 +83,8 @@ public class TagService : ITagService
                 offset = offset,
                 limit = limit,
                 total = await _context.Tags.CountAsync(filterResult ?? (t => true)),
-                nextOffset = offset + limit,
-                hasMore = await _context.Tags.Skip(offset + limit).AnyAsync(filterResult ?? (t => true))
+                next_offset = offset + limit,
+                has_more = await _context.Tags.Skip(offset + limit).AnyAsync(filterResult ?? (t => true))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null
@@ -145,15 +145,15 @@ public class TagService : ITagService
             {
                 errorQuery.Add(new ErrorDetail
                 {
-                    Reason = e.Message,
-                    Data = tagDto
+                    reason = e.Message,
+                    data = tagDto
                 });
             }
         }
         return new ReadBulkTagDto
         {
-            Valide = validQuery,
-            Error = errorQuery
+            valide = validQuery,
+            error = errorQuery
         };
     }
 

--- a/electrostoreAPI/Services/UserPushSubscriptionService/UserPushSubscriptionService.cs
+++ b/electrostoreAPI/Services/UserPushSubscriptionService/UserPushSubscriptionService.cs
@@ -37,13 +37,13 @@ public class UserPushSubscriptionService : IUserPushSubscriptionService
         var query = _context.UserPushSubscriptions.AsQueryable();
         var filterResult = default(Expression<Func<UserPushSubscriptions, bool>>);
         rsql ??= [];
-        rsql.Add(new FilterDto { Field = "id_user", SearchType = "eq", Value = userId.ToString() });
+        rsql.Add(new FilterDto { field = "id_user", search_type = "eq", value = userId.ToString() });
         if (rsql != null && rsql.Count > 0)
         {
             (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<UserPushSubscriptions>(rsql);
             query = query.Where(filterResult);
         }
-        if (!string.IsNullOrEmpty(sort?.Field))
+        if (!string.IsNullOrEmpty(sort?.field))
         {
             var sortResult = RsqlParserExtensions.ToSortExpression<UserPushSubscriptions>(sort);
             if (sortResult.Item1 != null)
@@ -52,7 +52,7 @@ public class UserPushSubscriptionService : IUserPushSubscriptionService
             }
             else
             {
-                sort = new SorterDto { Field = "created_at", Order = "desc" };
+                sort = new SorterDto { field = "created_at", order = "desc" };
                 query = query.OrderByDescending(s => s.created_at);
             }
         }
@@ -70,8 +70,8 @@ public class UserPushSubscriptionService : IUserPushSubscriptionService
                 offset = offset,
                 limit = limit,
                 total = await _context.UserPushSubscriptions.CountAsync(filterResult ?? (us => us.id_user == userId)),
-                nextOffset = offset + limit,
-                hasMore = await _context.UserPushSubscriptions.Skip(offset + limit).AnyAsync(filterResult ?? (us => us.id_user == userId))
+                next_offset = offset + limit,
+                has_more = await _context.UserPushSubscriptions.Skip(offset + limit).AnyAsync(filterResult ?? (us => us.id_user == userId))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null

--- a/electrostoreAPI/Services/UserService/UserService.cs
+++ b/electrostoreAPI/Services/UserService/UserService.cs
@@ -50,7 +50,7 @@ public class UserService : IUserService
                 (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<Users>(rsql);
                 query = query.Where(filterResult);
             }
-            if (!string.IsNullOrEmpty(sort?.Field))
+            if (!string.IsNullOrEmpty(sort?.field))
             {
                 var sortResult = RsqlParserExtensions.ToSortExpression<Users>(sort);
                 if (sortResult.Item1 != null)
@@ -59,7 +59,7 @@ public class UserService : IUserService
                 }
                 else
                 {
-                    sort = new SorterDto { Field = "id_user", Order = "asc" };
+                    sort = new SorterDto { field = "id_user", order = "asc" };
                     query = query.OrderBy(u => u.id_user);
                 }
             }
@@ -96,8 +96,8 @@ public class UserService : IUserService
                 offset = offset,
                 limit = limit,
                 total = await _context.Users.CountAsync(filterResult ?? (u => true)),
-                nextOffset = offset + limit,
-                hasMore = await _context.Users.Skip(offset + limit).AnyAsync(filterResult ?? (u => true))
+                next_offset = offset + limit,
+                has_more = await _context.Users.Skip(offset + limit).AnyAsync(filterResult ?? (u => true))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null

--- a/electrostoreAPI/Services/ZoneService/ZoneService.cs
+++ b/electrostoreAPI/Services/ZoneService/ZoneService.cs
@@ -44,7 +44,7 @@ public class ZoneService : IZoneService
                 (filterResult, rsql) = RsqlParserExtensions.ToFilterExpression<Zones>(rsql);
                 query = query.Where(filterResult);
             }
-            if (!string.IsNullOrEmpty(sort?.Field))
+            if (!string.IsNullOrEmpty(sort?.field))
             {
                 var sortResult = RsqlParserExtensions.ToSortExpression<Zones>(sort);
                 if (sortResult.Item1 != null)
@@ -53,7 +53,7 @@ public class ZoneService : IZoneService
                 }
                 else
                 {
-                    sort = new SorterDto { Field = "id_zone", Order = "asc" };
+                    sort = new SorterDto { field = "id_zone", order = "asc" };
                     query = query.OrderBy(z => z.id_zone);
                 }
             }
@@ -86,8 +86,8 @@ public class ZoneService : IZoneService
                 offset = offset,
                 limit = limit,
                 total = await _context.Zones.CountAsync(filterResult ?? (z => true)),
-                nextOffset = offset + limit,
-                hasMore = await _context.Zones.Skip(offset + limit).AnyAsync(filterResult ?? (z => true))
+                next_offset = offset + limit,
+                has_more = await _context.Zones.Skip(offset + limit).AnyAsync(filterResult ?? (z => true))
             },
             filters = rsql,
             sort = sort != null ? [sort] : null

--- a/tests/electrostoreAPI/Extensions/ParserExtensionsTests.cs
+++ b/tests/electrostoreAPI/Extensions/ParserExtensionsTests.cs
@@ -32,8 +32,8 @@ public class ParserExtensionsTests
 
         // Assert
         var filter = Assert.Single(result);
-        Assert.Equal("field", filter.Field);
-        Assert.Equal(expectedSearchType, filter.SearchType);
+        Assert.Equal("field", filter.field);
+        Assert.Equal(expectedSearchType, filter.search_type);
     }
 
     [Fact]
@@ -44,9 +44,9 @@ public class ParserExtensionsTests
 
         // Assert
         var filter = Assert.Single(result);
-        Assert.Equal("field", filter.Field);
-        Assert.Equal("null", filter.SearchType);
-        Assert.Equal("", filter.Value);
+        Assert.Equal("field", filter.field);
+        Assert.Equal("null", filter.search_type);
+        Assert.Equal("", filter.value);
     }
 
     [Fact]
@@ -57,12 +57,12 @@ public class ParserExtensionsTests
 
         // Assert
         Assert.Equal(2, result.Count);
-        Assert.Equal("a", result[0].Field);
-        Assert.Equal("1", result[0].Value);
-        Assert.Equal("eq", result[0].SearchType);
-        Assert.Equal("b", result[1].Field);
-        Assert.Equal("2", result[1].Value);
-        Assert.Equal("gt", result[1].SearchType);
+        Assert.Equal("a", result[0].field);
+        Assert.Equal("1", result[0].value);
+        Assert.Equal("eq", result[0].search_type);
+        Assert.Equal("b", result[1].field);
+        Assert.Equal("2", result[1].value);
+        Assert.Equal("gt", result[1].search_type);
     }
 
     [Fact]
@@ -93,7 +93,7 @@ public class ParserExtensionsTests
 
         // Assert
         var filter = Assert.Single(result);
-        Assert.Equal("a", filter.Field);
+        Assert.Equal("a", filter.field);
     }
 
     // --- ParseSort ---
@@ -105,8 +105,8 @@ public class ParserExtensionsTests
         var result = ParserExtensions.ParseSort(null!);
 
         // Assert
-        Assert.Equal("", result.Field);
-        Assert.Equal("asc", result.Order);
+        Assert.Equal("", result.field);
+        Assert.Equal("asc", result.order);
     }
 
     [Fact]
@@ -116,8 +116,8 @@ public class ParserExtensionsTests
         var result = ParserExtensions.ParseSort("");
 
         // Assert
-        Assert.Equal("", result.Field);
-        Assert.Equal("asc", result.Order);
+        Assert.Equal("", result.field);
+        Assert.Equal("asc", result.order);
     }
 
     [Fact]
@@ -127,8 +127,8 @@ public class ParserExtensionsTests
         var result = ParserExtensions.ParseSort("fieldonly");
 
         // Assert
-        Assert.Equal("", result.Field);
-        Assert.Equal("asc", result.Order);
+        Assert.Equal("", result.field);
+        Assert.Equal("asc", result.order);
     }
 
     [Theory]
@@ -142,8 +142,8 @@ public class ParserExtensionsTests
         var result = ParserExtensions.ParseSort(input);
 
         // Assert
-        Assert.Equal(expectedField, result.Field);
-        Assert.Equal(expectedOrder, result.Order);
+        Assert.Equal(expectedField, result.field);
+        Assert.Equal(expectedOrder, result.order);
     }
 
     [Fact]
@@ -153,7 +153,7 @@ public class ParserExtensionsTests
         var result = ParserExtensions.ParseSort(" field , desc ");
 
         // Assert
-        Assert.Equal("field", result.Field);
-        Assert.Equal("desc", result.Order);
+        Assert.Equal("field", result.field);
+        Assert.Equal("desc", result.order);
     }
 }

--- a/tests/electrostoreAPI/Services/AuthServiceTests.cs
+++ b/tests/electrostoreAPI/Services/AuthServiceTests.cs
@@ -97,10 +97,10 @@ namespace ElectrostoreAPI.Tests.Services
             var result = await authService.GetSSOAuthUrl("google");
             // Assert
             Assert.NotNull(result);
-            Assert.NotEmpty(result.State);
-            Assert.StartsWith("https://provider.example.com/authorize?", result.AuthUrl);
-            Assert.Contains("client_id=client-id", result.AuthUrl);
-            Assert.Contains("state=", result.AuthUrl);
+            Assert.NotEmpty(result.state);
+            Assert.StartsWith("https://provider.example.com/authorize?", result.auth_url);
+            Assert.Contains("client_id=client-id", result.auth_url);
+            Assert.Contains("state=", result.auth_url);
         }
 
         [Fact]
@@ -114,7 +114,7 @@ namespace ElectrostoreAPI.Tests.Services
             var result = await authService.GetSSOAuthUrl("google_workspace");
             // Assert
             Assert.NotNull(result);
-            Assert.StartsWith("https://provider.example.com/authorize?", result.AuthUrl);
+            Assert.StartsWith("https://provider.example.com/authorize?", result.auth_url);
         }
 
         [Fact]
@@ -140,7 +140,7 @@ namespace ElectrostoreAPI.Tests.Services
             using var context = new ApplicationDbContext(_dbContextOptions);
             var configuration = BuildEmptyConfiguration();
             var authService = CreateService(context, configuration);
-            var request = new SsoLoginRequest { Code = "some-code", State = "invalid-state-" + Guid.NewGuid() };
+            var request = new SsoLoginRequest { code = "some-code", state = "invalid-state-" + Guid.NewGuid() };
             // Act & Assert
             await Assert.ThrowsAsync<UnauthorizedAccessException>(async () =>
             {
@@ -245,7 +245,7 @@ namespace ElectrostoreAPI.Tests.Services
             // Act & Assert
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
-                await authService.ForgotPassword(new ForgotPasswordRequest { Email = "user@test.com" });
+                await authService.ForgotPassword(new ForgotPasswordRequest { email = "user@test.com" });
             });
         }
 
@@ -259,7 +259,7 @@ namespace ElectrostoreAPI.Tests.Services
             var configuration = BuildEmptyConfiguration();
             var authService = CreateService(context, configuration);
             // Act
-            await authService.ForgotPassword(new ForgotPasswordRequest { Email = "user@test.com" });
+            await authService.ForgotPassword(new ForgotPasswordRequest { email = "user@test.com" });
             // Assert
             var user = await context.Users.FindAsync(1);
             Assert.NotNull(user!.reset_token);
@@ -277,7 +277,7 @@ namespace ElectrostoreAPI.Tests.Services
             // Act
             var exception = await Record.ExceptionAsync(async () =>
             {
-                await authService.ForgotPassword(new ForgotPasswordRequest { Email = "missing@test.com" });
+                await authService.ForgotPassword(new ForgotPasswordRequest { email = "missing@test.com" });
             });
             // Assert
             Assert.Null(exception);
@@ -295,7 +295,7 @@ namespace ElectrostoreAPI.Tests.Services
             // Act & Assert
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
-                await authService.ResetPassword(new ResetPasswordRequest { Email = "user@test.com", Token = Guid.NewGuid().ToString(), Password = "NewPassword1!" });
+                await authService.ResetPassword(new ResetPasswordRequest { email = "user@test.com", token = Guid.NewGuid().ToString(), password = "NewPassword1!" });
             });
         }
 
@@ -314,7 +314,7 @@ namespace ElectrostoreAPI.Tests.Services
             // Act & Assert
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
-                await authService.ResetPassword(new ResetPasswordRequest { Email = "user@test.com", Token = Guid.NewGuid().ToString(), Password = "NewPassword1!" });
+                await authService.ResetPassword(new ResetPasswordRequest { email = "user@test.com", token = Guid.NewGuid().ToString(), password = "NewPassword1!" });
             });
         }
 
@@ -334,7 +334,7 @@ namespace ElectrostoreAPI.Tests.Services
             // Act & Assert
             await Assert.ThrowsAsync<InvalidOperationException>(async () =>
             {
-                await authService.ResetPassword(new ResetPasswordRequest { Email = "user@test.com", Token = resetToken.ToString(), Password = "NewPassword1!" });
+                await authService.ResetPassword(new ResetPasswordRequest { email = "user@test.com", token = resetToken.ToString(), password = "NewPassword1!" });
             });
         }
 
@@ -352,7 +352,7 @@ namespace ElectrostoreAPI.Tests.Services
             var configuration = BuildEmptyConfiguration();
             var authService = CreateService(context, configuration);
             // Act
-            await authService.ResetPassword(new ResetPasswordRequest { Email = "user@test.com", Token = resetToken.ToString(), Password = "NewPassword1!" });
+            await authService.ResetPassword(new ResetPasswordRequest { email = "user@test.com", token = resetToken.ToString(), password = "NewPassword1!" });
             // Assert
             var updatedUser = await context.Users.FindAsync(1);
             Assert.True(BCrypt.Net.BCrypt.Verify("NewPassword1!", updatedUser!.password_user));
@@ -381,7 +381,7 @@ namespace ElectrostoreAPI.Tests.Services
             _jwtService.Setup(j => j.GenerateToken(It.IsAny<ReadUserDto>(), "user_password")).ReturnsAsync(jwt);
             var authService = CreateService(context, BuildEmptyConfiguration());
             // Act
-            var result = await authService.LoginWithPassword(new LoginRequest { Email = "user@test.com", Password = "Password1!" });
+            var result = await authService.LoginWithPassword(new LoginRequest { email = "user@test.com", password = "Password1!" });
             // Assert
             Assert.Equal("access-token", result.token);
             Assert.Equal("refresh-token", result.refresh_token);
@@ -398,7 +398,7 @@ namespace ElectrostoreAPI.Tests.Services
             // Act & Assert
             await Assert.ThrowsAsync<UnauthorizedAccessException>(async () =>
             {
-                await authService.LoginWithPassword(new LoginRequest { Email = "missing@test.com", Password = "Password1!" });
+                await authService.LoginWithPassword(new LoginRequest { email = "missing@test.com", password = "Password1!" });
             });
         }
 
@@ -413,7 +413,7 @@ namespace ElectrostoreAPI.Tests.Services
             // Act & Assert
             await Assert.ThrowsAsync<UnauthorizedAccessException>(async () =>
             {
-                await authService.LoginWithPassword(new LoginRequest { Email = "user@test.com", Password = "WrongPassword1!" });
+                await authService.LoginWithPassword(new LoginRequest { email = "user@test.com", password = "WrongPassword1!" });
             });
         }
 

--- a/tests/electrostoreAPI/Services/FileServiceTests.cs
+++ b/tests/electrostoreAPI/Services/FileServiceTests.cs
@@ -117,9 +117,9 @@ namespace ElectrostoreAPI.Tests.Services
             var result = await fileService.GetFile("test-file.txt");
 
             // Assert
-            Assert.True(result.Success);
-            Assert.NotNull(result.FileStream);
-            Assert.Equal("text/plain", result.MimeType);
+            Assert.True(result.success);
+            Assert.NotNull(result.file_stream);
+            Assert.Equal("text/plain", result.mime_type);
         }
 
         [Fact]
@@ -137,8 +137,8 @@ namespace ElectrostoreAPI.Tests.Services
             var result = await fileService.GetFile("non-existent-file.txt");
 
             // Assert
-            Assert.False(result.Success);
-            Assert.Equal("File not found", result.ErrorMessage);
+            Assert.False(result.success);
+            Assert.Equal("File not found", result.error_message);
         }
 
         [Fact]
@@ -157,9 +157,9 @@ namespace ElectrostoreAPI.Tests.Services
             var result = await fileService.GetFile("test-file.txt");
 
             // Assert
-            Assert.True(result.Success);
-            Assert.NotNull(result.FileStream);
-            Assert.Equal("text/plain", result.MimeType);
+            Assert.True(result.success);
+            Assert.NotNull(result.file_stream);
+            Assert.Equal("text/plain", result.mime_type);
 
             // Cleanup
             File.Delete(testFilePath);
@@ -177,8 +177,8 @@ namespace ElectrostoreAPI.Tests.Services
             var result = await fileService.GetFile("non-existent-local-file.txt");
 
             // Assert
-            Assert.False(result.Success);
-            Assert.Equal("File not found", result.ErrorMessage);
+            Assert.False(result.success);
+            Assert.Equal("File not found", result.error_message);
         }
 
         // --- FileExists ---
@@ -284,7 +284,7 @@ namespace ElectrostoreAPI.Tests.Services
             // Assert
             Assert.NotNull(result);
             Assert.Contains("some-path", result.path);
-            Assert.Equal("text/plain", result.mimeType);
+            Assert.Equal("text/plain", result.mime_type);
         }
 
         [Fact]
@@ -308,7 +308,7 @@ namespace ElectrostoreAPI.Tests.Services
             // Assert
             Assert.NotNull(result);
             Assert.Contains("local-path", result.path);
-            Assert.Equal("text/plain", result.mimeType);
+            Assert.Equal("text/plain", result.mime_type);
 
             // Cleanup
             var savedFilePath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot", result.path);
@@ -560,7 +560,7 @@ namespace ElectrostoreAPI.Tests.Services
             Assert.NotNull(thumbnailResult);
             Assert.Contains("main", saveResult.path);
             Assert.Contains("thumbnails", thumbnailResult.path);
-            Assert.Equal("image/jpeg", thumbnailResult.mimeType);
+            Assert.Equal("image/jpeg", thumbnailResult.mime_type);
 
             // Cleanup
             var savedThumbnailPath = Path.Combine(Directory.GetCurrentDirectory(), "wwwroot", thumbnailResult.path);

--- a/tests/electrostoreAPI/Services/StatusServiceTests.cs
+++ b/tests/electrostoreAPI/Services/StatusServiceTests.cs
@@ -113,7 +113,7 @@ namespace ElectrostoreAPI.Tests.Services
             Assert.Equal(2, result.ai_training_in_progress);
             Assert.Equal("healthy", result.notif_status);
             Assert.True(result.notif_smtp);
-            Assert.False(result.notif_webPush);
+            Assert.False(result.notif_web_push);
             Assert.Equal("healthy", result.cron_status);
             Assert.Equal("healthy", result.worker_status);
         }


### PR DESCRIPTION
Refactored DTO and result object property names from mixed/Pascal casing to snake_case across the API (auth requests, file/encryption results, filters/sorters, pagination, bulk response/error payloads, and status fields). Updated all dependent controllers, services, parser extensions, and unit tests to use the new property names so behavior remains consistent while aligning response/request contracts with the project naming convention.